### PR TITLE
Helpers

### DIFF
--- a/README.md
+++ b/README.md
@@ -245,6 +245,22 @@ including conditionals, loops, and functions. Boilerplate also includes several 
    return str2;
    // boilerplate-snippet: foo
    ```
+1. `downcase STRING`: Convert `STRING` to lower case. E.g. "FOO" becomes "foo".
+1. `upcase STRING`: Convert `STRING` to upper case. E.g. "foo" becomes "FOO".
+1. `capitalize STRING`: Capitalize the first letter of each word in `STRING`. E.g. "foo bar baz" becomes "Foo Bar Baz".
+1. `replace OLD NEW`: Replace the first occurrence of `OLD` with `NEW`. This is a literal replace, not regex.
+1. `replaceAll OLD NEW`: Replace all occurrences of `OLD` with `NEW`. This is a literal replace, not regex.
+1. `trim STRING`: Remove leading and trailing whitespace from `STRING`.
+1. `round FLOAT`: Round `FLOAT` to the nearest integer. E.g. 1.5 becomes 2.
+1. `ceil FLOAT`: Round up `FLOAT` to the nearest integer. E.g. 1.5 becomes 2.
+1. `floor FLOAT`: Round down `FLOAT` to the nearest integer. E.g. 1.5 becomes 1.
+1. `dasherize STRING`: Convert `STRING` to a lower case string separated by dashes. E.g. "foo Bar baz" becomes
+   "foo-bar-baz".
+1. `snakeCase STRING`: Convert `STRING` to a lower case string separated by underscores. E.g. "foo Bar baz" becomes
+   "foo_bar_baz".
+1. `camelCase STRING`: Convert `STRING` to a camel case string. E.g. "foo Bar baz" becomes "FooBarBaz".
+1. `camelCaseLower STRING`: Convert `STRING` to a camel case string where the first letter is lower case. E.g.
+   "foo Bar baz" becomes "fooBarBaz".
 
 ## Alternative project generators
 
@@ -296,8 +312,6 @@ This code is released under the MIT License. See LICENSE.txt.
      file: echo "Boilerplate is processing file $1"
      end: echo "Boilerplate finished generating files in $2 from templates in $1"
    ```
-1. Consider open sourcing boilerplate. To do that, we may also want to open source the
-   `gruntwork-module-circleci-helpers` it uses in `circle.yml`.
 1. Support a list of `ignore` files in `boilerplate.yml` or even a `.boilerplate-ignore` file for files that should be
    skipped over while generating code.
 1. Consider supporting different types for variables. Currently, all variables are strings, but there may be value

--- a/templates/template_helpers_test.go
+++ b/templates/template_helpers_test.go
@@ -219,3 +219,229 @@ func TestWrapWithTemplatePath(t *testing.T) {
 	assert.Nil(t, err)
 	assert.Equal(t, expected, actual)
 }
+
+func TestDasherize(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"", ""},
+		{"     ", ""},
+		{"foo", "foo"},
+		{"FOO", "foo"},
+		{" \t  foo   \t", "foo"},
+		{"FooBarBaz", "foo-bar-baz"},
+		{"Fo", "fo"},
+		{"fooID", "foo-id"},
+		{"FoB", "fo-b"},
+		{"oFo", "o-fo"},
+		{"FoBa", "fo-ba"},
+		{"oFoBa", "o-fo-ba"},
+		{"oFoB", "o-fo-b"},
+		{"Foo123B1234Baz1234", "foo123-b1234-baz1234"},
+		{"Foo_Bar_Baz", "foo-bar-baz"},
+		{"FooIDbarBaz", "foo-idbar-baz"},
+		{"FOOIDbarBaz", "fooidbar-baz"},
+		{" A B C ", "a-b-c"},
+		{"foo bar baz", "foo-bar-baz"},
+		{"foo \t \tbar   baz \t", "foo-bar-baz"},
+		{"foo_bar_baz", "foo-bar-baz"},
+		{"_foo_bar_baz_", "foo-bar-baz"},
+		{"foo-bar-baz", "foo-bar-baz"},
+		{"foo--bar----baz", "foo-bar-baz"},
+		{"foo__bar____baz", "foo-bar-baz"},
+		{" Foo Bar Baz ", "foo-bar-baz"},
+		{" Foo Bar_BazBlah ", "foo-bar-baz-blah"},
+		{" Foo.Bar.Baz", "foo-bar-baz"},
+		{"#@!Foo@#$@$Bar>>>>>Baz", "foo-bar-baz"},
+	}
+
+	for _, testCase := range testCases {
+		actual := dasherize(testCase.input)
+		assert.Equal(t, testCase.expected, actual, "When calling dasherize on '%s', expected '%s', but got '%s'", testCase.input, testCase.expected, actual)
+	}
+}
+
+func TestSnakeCase(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"", ""},
+		{"     ", ""},
+		{"foo", "foo"},
+		{"FOO", "foo"},
+		{" \t  foo   \t", "foo"},
+		{"FooBarBaz", "foo_bar_baz"},
+		{"Fo", "fo"},
+		{"fooID", "foo_id"},
+		{"FoB", "fo_b"},
+		{"oFo", "o_fo"},
+		{"FoBa", "fo_ba"},
+		{"oFoBa", "o_fo_ba"},
+		{"oFoB", "o_fo_b"},
+		{"Foo123B1234Baz1234", "foo123_b1234_baz1234"},
+		{"Foo_Bar_Baz", "foo_bar_baz"},
+		{"FooIDbarBaz", "foo_idbar_baz"},
+		{"FOOIDbarBaz", "fooidbar_baz"},
+		{" A B C ", "a_b_c"},
+		{"foo bar baz", "foo_bar_baz"},
+		{"foo \t \tbar   baz \t", "foo_bar_baz"},
+		{"foo_bar_baz", "foo_bar_baz"},
+		{"_foo_bar_baz_", "foo_bar_baz"},
+		{"foo-bar-baz", "foo_bar_baz"},
+		{"foo--bar----baz", "foo_bar_baz"},
+		{"foo__bar____baz", "foo_bar_baz"},
+		{" Foo Bar Baz ", "foo_bar_baz"},
+		{" Foo Bar_BazBlah ", "foo_bar_baz_blah"},
+		{" Foo.Bar.Baz", "foo_bar_baz"},
+		{"#@!Foo@#$@$Bar>>>>>Baz", "foo_bar_baz"},
+	}
+
+	for _, testCase := range testCases {
+		actual := snakeCase(testCase.input)
+		assert.Equal(t, testCase.expected, actual, "When calling snakeCase on '%s', expected '%s', but got '%s'", testCase.input, testCase.expected, actual)
+	}
+}
+
+func TestCamelCase(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"", ""},
+		{"     ", ""},
+		{"foo", "Foo"},
+		{"FOO", "FOO"},
+		{" \t  foo   \t", "Foo"},
+		{"FooBarBaz", "FooBarBaz"},
+		{"Fo", "Fo"},
+		{"fooID", "FooID"},
+		{"FoB", "FoB"},
+		{"oFo", "OFo"},
+		{"FoBa", "FoBa"},
+		{"oFoBa", "OFoBa"},
+		{"oFoB", "OFoB"},
+		{"Foo123B1234Baz1234", "Foo123B1234Baz1234"},
+		{"Foo_Bar_Baz", "FooBarBaz"},
+		{"FooIDbarBaz", "FooIDbarBaz"},
+		{"FOOIDbarBaz", "FOOIDbarBaz"},
+		{" A B C ", "ABC"},
+		{"foo bar baz", "FooBarBaz"},
+		{"foo \t \tbar   baz \t", "FooBarBaz"},
+		{"foo_bar_baz", "FooBarBaz"},
+		{"_foo_bar_baz_", "FooBarBaz"},
+		{"foo-bar-baz", "FooBarBaz"},
+		{"foo--bar----baz", "FooBarBaz"},
+		{"foo__bar____baz", "FooBarBaz"},
+		{" Foo Bar Baz ", "FooBarBaz"},
+		{" Foo Bar_BazBlah ", "FooBarBazBlah"},
+		{" Foo.Bar.Baz", "FooBarBaz"},
+		{"#@!Foo@#$@$Bar>>>>>Baz", "FooBarBaz"},
+	}
+
+	for _, testCase := range testCases {
+		actual := camelCase(testCase.input)
+		assert.Equal(t, testCase.expected, actual, "When calling camelCase on '%s', expected '%s', but got '%s'", testCase.input, testCase.expected, actual)
+	}
+}
+
+func TestCamelCaseLower(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"", ""},
+		{"     ", ""},
+		{"foo", "foo"},
+		{"FOO", "fOO"},
+		{" \t  foo   \t", "foo"},
+		{"FooBarBaz", "fooBarBaz"},
+		{"Fo", "fo"},
+		{"fooID", "fooID"},
+		{"FoB", "foB"},
+		{"oFo", "oFo"},
+		{"FoBa", "foBa"},
+		{"oFoBa", "oFoBa"},
+		{"oFoB", "oFoB"},
+		{"Foo123B1234Baz1234", "foo123B1234Baz1234"},
+		{"Foo_Bar_Baz", "fooBarBaz"},
+		{"FooIDbarBaz", "fooIDbarBaz"},
+		{"FOOIDbarBaz", "fOOIDbarBaz"},
+		{" A B C ", "aBC"},
+		{"foo bar baz", "fooBarBaz"},
+		{"foo \t \tbar   baz \t", "fooBarBaz"},
+		{"foo_bar_baz", "fooBarBaz"},
+		{"_foo_bar_baz_", "fooBarBaz"},
+		{"foo-bar-baz", "fooBarBaz"},
+		{"foo--bar----baz", "fooBarBaz"},
+		{"foo__bar____baz", "fooBarBaz"},
+		{" Foo Bar Baz ", "fooBarBaz"},
+		{" Foo Bar_BazBlah ", "fooBarBazBlah"},
+		{" Foo.Bar.Baz", "fooBarBaz"},
+		{"#@!Foo@#$@$Bar>>>>>Baz", "fooBarBaz"},
+	}
+
+	for _, testCase := range testCases {
+		actual := camelCaseLower(testCase.input)
+		assert.Equal(t, testCase.expected, actual, "When calling camelCaseLower on '%s', expected '%s', but got '%s'", testCase.input, testCase.expected, actual)
+	}
+}
+
+func TestLowerFirst(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		input    string
+		expected string
+	}{
+		{"", ""},
+		{"     ", "     "},
+		{"foo", "foo"},
+		{"Foo", "foo"},
+		{"FOO", "fOO"},
+		{"Здравейте", "здравейте"},
+	}
+
+	for _, testCase := range testCases {
+		actual := lowerFirst(testCase.input)
+		assert.Equal(t, testCase.expected, actual, "When calling lowerFirst on '%s', expected '%s', but got '%s'", testCase.input, testCase.expected, actual)
+	}
+}
+
+// I cannot believe I have to write my own function and test code for rounding numbers in Go. FML.
+func TestRound(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		input    float64
+		expected int
+	}{
+		{0, 0},
+		{0.0, 0},
+		{0.25, 0},
+		{0.49, 0},
+		{0.4999999999999, 0},
+		{0.5, 1},
+		{0.50000000000000001, 1},
+		{0.75, 1},
+		{0.999999999999999, 1},
+		{1, 1},
+		{1.0, 1},
+		{151515151.234234234, 151515151},
+	}
+
+	for _, testCase := range testCases {
+		actual := round(testCase.input)
+		assert.Equal(t, testCase.expected, actual, "When calling round on %f, expected %d, but got %d", testCase.input, testCase.expected, actual)
+	}
+}
+

--- a/templates/template_processor_test.go
+++ b/templates/template_processor_test.go
@@ -91,6 +91,7 @@ func TestRenderTemplate(t *testing.T) {
 		{"Snake case test: {{ .Foo | snakeCase }}", map[string]string{"Foo": "foo BAR baz!"}, "", "Snake case test: foo_bar_baz"},
 		{"Camel case test: {{ .Foo | camelCase }}", map[string]string{"Foo": "foo BAR baz!"}, "", "Camel case test: FooBARBaz"},
 		{"Camel case lower test: {{ .Foo | camelCaseLower }}", map[string]string{"Foo": "foo BAR baz!"}, "", "Camel case lower test: fooBARBaz"},
+		{"Filter chain test: {{ .Foo | downcase | replaceAll \" \" \"\" }}", map[string]string{"Foo": "foo BAR baz!"}, "", "Filter chain test: foobarbaz!"},
 	}
 
 	for _, testCase := range testCases {

--- a/templates/template_processor_test.go
+++ b/templates/template_processor_test.go
@@ -78,6 +78,19 @@ func TestRenderTemplate(t *testing.T) {
 		{EMBED_WHOLE_FILE_TEMPLATE, map[string]string{}, "", EMBED_WHOLE_FILE_TEMPLATE_OUTPUT},
 		{EMBED_SNIPPET_TEMPLATE, map[string]string{}, "", EMBED_SNIPPET_TEMPLATE_OUTPUT},
 		{"Invalid template syntax: {{.Foo", map[string]string{}, "unclosed action", ""},
+		{"Uppercase test: {{ .Foo | upcase }}", map[string]string{"Foo": "some text"}, "", "Uppercase test: SOME TEXT"},
+		{"Lowercase test: {{ .Foo | downcase }}", map[string]string{"Foo": "SOME TEXT"}, "", "Lowercase test: some text"},
+		{"Capitalize test: {{ .Foo | capitalize }}", map[string]string{"Foo": "some text"}, "", "Capitalize test: Some Text"},
+		{"Replace test: {{ .Foo | replace \"foo\" \"bar\" }}", map[string]string{"Foo": "hello foo, how are foo"}, "", "Replace test: hello bar, how are foo"},
+		{"Replace all test: {{ .Foo | replaceAll \"foo\" \"bar\" }}", map[string]string{"Foo": "hello foo, how are foo"}, "", "Replace all test: hello bar, how are bar"},
+		{"Trim test: {{ .Foo | trim }}", map[string]string{"Foo": "   some text     \t"}, "", "Trim test: some text"},
+		{"Round test: {{ .Foo | round }}", map[string]string{"Foo": "0.45"}, "", "Round test: 0"},
+		{"Ceil test: {{ .Foo | ceil }}", map[string]string{"Foo": "0.45"}, "", "Ceil test: 1"},
+		{"Floor test: {{ .Foo | floor }}", map[string]string{"Foo": "0.45"}, "", "Floor test: 0"},
+		{"Dasherize test: {{ .Foo | dasherize }}", map[string]string{"Foo": "foo BAR baz!"}, "", "Dasherize test: foo-bar-baz"},
+		{"Snake case test: {{ .Foo | snakeCase }}", map[string]string{"Foo": "foo BAR baz!"}, "", "Snake case test: foo_bar_baz"},
+		{"Camel case test: {{ .Foo | camelCase }}", map[string]string{"Foo": "foo BAR baz!"}, "", "Camel case test: FooBARBaz"},
+		{"Camel case lower test: {{ .Foo | camelCaseLower }}", map[string]string{"Foo": "foo BAR baz!"}, "", "Camel case lower test: fooBARBaz"},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
This PR adds a bunch of handy string and math helpers to boilerplate, such as `dasherize`, `snakeCase`, and `round`. This allows us to use a single value entered by a user in many different ways. For example, if a `boilerplate.yml` file defines a variable called `companyName`, and the user enters the name “Acme Co”, with these helpers, it’s now easy to generate a variety of different types of valid code with that text, such as:

* Java package name: `{{ .companyName | camelCase }}` => “AcmeCo”
* Terraform resource name: `{{ .companyName | snakeCase }}` => “acme_co”
* CSS class name: `{{ .companyName | dasherize }}` => “acme-co”

BTW, this took quite a bit longer than expected because Go does not have many of these basic string and math manipulation functions built in. It doesn't even have a method to round numbers!! I found some open source implementations, but most were broken and incomplete, so I implemented my own with a thorough suite of tests.