### PR TITLE
Support a configurable missing key action

### DIFF
--- a/README.md
+++ b/README.md
@@ -148,6 +148,9 @@ The `boilerplate` binary supports the following options:
   `--var-file` options instead.
 * `--var NAME=VALUE` (optional): Use `NAME=VALUE` to set variable `NAME` to `VALUE`. May be specified more than once.
 * `--var-file FILE` (optional): Load variable values from the YAML file `FILE`. May be specified more than once.
+* `--missing-key-action ACTION` (optional): What to do if a template looks up a variable that is not defined. Must
+  be one of: `invalid` (render the text "<no value>"), `zero` (render the zero value for the variable), or `error`
+  (return an error and exit immediately). Default: `error`.
 * `--help`: Show the help text and exit.
 * `--version`: Show the version and exit.
 

--- a/cli/boilerplate_cli.go
+++ b/cli/boilerplate_cli.go
@@ -77,7 +77,7 @@ func CreateBoilerplateCli(version string) *cli.App {
 		},
 		cli.StringFlag{
 			Name: config.OPT_MISSING_KEY_ACTION,
-			Usage: "What to do if a template looks up a variable that is not defined. Must be one of: 'invalid' (render the text '<no value>'), 'zero' (render the zero value for the variable), or 'error' (return an error and exit immediately). Default: 'error'.",
+			Usage: fmt.Sprintf("What `ACTION` to take if a template looks up a variable that is not defined. Must be one of: %s. Default: %s.", config.ALL_MISSING_KEY_ACTIONS, config.DEFAULT_MISSING_KEY_ACTION),
 		},
 	}
 

--- a/cli/boilerplate_cli.go
+++ b/cli/boilerplate_cli.go
@@ -118,9 +118,9 @@ func parseOptions(cliContext *cli.Context) (*config.BoilerplateOptions, error) {
 	}
 
 	missingKeyAction := config.DEFAULT_MISSING_KEY_ACTION
-	missingKeyActionName := cliContext.String(config.OPT_MISSING_KEY_ACTION)
-	if missingKeyActionName != "" {
-		missingKeyAction, err = config.ParseMissingKeyAction(missingKeyActionName)
+	missingKeyActionValue := cliContext.String(config.OPT_MISSING_KEY_ACTION)
+	if missingKeyActionValue != "" {
+		missingKeyAction, err = config.ParseMissingKeyAction(missingKeyActionValue)
 		if err != nil {
 			return nil, err
 		}

--- a/cli/boilerplate_cli.go
+++ b/cli/boilerplate_cli.go
@@ -117,8 +117,8 @@ func parseOptions(cliContext *cli.Context) (*config.BoilerplateOptions, error) {
 		return nil, err
 	}
 
-	missingKeyActionName := cliContext.String(config.OPT_MISSING_KEY_ACTION)
 	missingKeyAction := config.DEFAULT_MISSING_KEY_ACTION
+	missingKeyActionName := cliContext.String(config.OPT_MISSING_KEY_ACTION)
 	if missingKeyActionName != "" {
 		missingKeyAction, err = config.ParseMissingKeyAction(missingKeyActionName)
 		if err != nil {

--- a/config/config.go
+++ b/config/config.go
@@ -35,6 +35,8 @@ func (action MissingKeyAction) String() string {
 	return missingKeyNames[int(action)]
 }
 
+// Convert the given string to a MissingKeyAction enum, or return an error if this is not a valid value for the
+// MissingKeyAction enum
 func ParseMissingKeyAction(keyName string) (MissingKeyAction, error) {
 	for i, missingKeyName := range missingKeyNames {
 		if missingKeyName == keyName {
@@ -62,7 +64,6 @@ var (
 )
 
 var ALL_MISSING_KEY_ACTIONS = []MissingKeyAction{Invalid, ZeroValue, ExitWithError}
-
 var DEFAULT_MISSING_KEY_ACTION = ExitWithError
 
 // Validate that the options have reasonable values and return an error if they don't

--- a/config/config.go
+++ b/config/config.go
@@ -16,14 +16,54 @@ const OPT_OUTPUT_FOLDER = "output-folder"
 const OPT_NON_INTERACTIVE = "non-interactive"
 const OPT_VAR = "var"
 const OPT_VAR_FILE = "var-file"
+const OPT_MISSING_KEY_ACTION = "missing-key-action"
 
 // The command-line options for the boilerplate app
 type BoilerplateOptions struct {
-	TemplateFolder 	string
-	OutputFolder 	string
-	NonInteractive	bool
-	Vars		map[string]string
+	TemplateFolder 	 string
+	OutputFolder 	 string
+	NonInteractive	 bool
+	Vars		 map[string]string
+	OnMissingKey     MissingKeyAction
 }
+
+// This type is an enum that represents what we can do when a template looks up a missing key. This typically happens
+// when there is a typo in the variable name in a template.
+type MissingKeyAction int
+
+func (action MissingKeyAction) String() string {
+	return missingKeyNames[int(action)]
+}
+
+func ParseMissingKeyAction(keyName string) (MissingKeyAction, error) {
+	for i, missingKeyName := range missingKeyNames {
+		if missingKeyName == keyName {
+			return MissingKeyAction(i), nil
+		}
+	}
+	return MissingKeyAction(-1), errors.WithStackTrace(InvalidMissingKeyAction(keyName))
+}
+
+// The names of the missing keys. Go doesn't have enums, so we have to roll our own based on this example:
+// https://gist.github.com/skarllot/102a5e5ea73861ff5afe
+var missingKeyNames = []string{}
+
+// Create a new MissingKeyAction enum with the given name
+func newMissingKeyAction(name string) MissingKeyAction {
+	missingKeyNames = append(missingKeyNames, name)
+	return MissingKeyAction(len(missingKeyNames) - 1)
+}
+
+// Here are the MissingKeyAction enum values
+var (
+	Invalid = newMissingKeyAction("invalid")	// print <no value> for any missing key
+	ZeroValue = newMissingKeyAction("zero")		// print the zero value of the missing key
+	ExitWithError = newMissingKeyAction("error")	// exit with an error when there is a missing key
+)
+
+var ALL_MISSING_KEY_ACTIONS = []MissingKeyAction{Invalid, ZeroValue, ExitWithError}
+
+var DEFAULT_MISSING_KEY_ACTION = ExitWithError
 
 // Validate that the options have reasonable values and return an error if they don't
 func (options *BoilerplateOptions) Validate() error {
@@ -116,3 +156,7 @@ func (err TemplateFolderDoesNotExist) Error() string {
 	return fmt.Sprintf("Folder %s does not exist", string(err))
 }
 
+type InvalidMissingKeyAction string
+func (err InvalidMissingKeyAction) Error() string {
+	return fmt.Sprintf("Invalid MissingKeyAction '%s'. Value must be one of: %s", string(err), missingKeyNames)
+}

--- a/integration-tests/examples_test.go
+++ b/integration-tests/examples_test.go
@@ -10,6 +10,7 @@ import (
 	"os/exec"
 	"os"
 	"strings"
+	"github.com/gruntwork-io/boilerplate/config"
 )
 
 // Our integration tests run through all the examples in the /examples folder, generate them, and check that they
@@ -31,16 +32,18 @@ func TestExamples(t *testing.T) {
 	app := cli.CreateBoilerplateCli("test")
 
 	for _, file := range files {
-		if file.IsDir() {
-			templateFolder := path.Join(examplesBasePath, file.Name())
-			outputFolder := path.Join(outputBasePath, file.Name())
-			varFile := path.Join(examplesVarFilesBasePath, file.Name(), "vars.yml")
-			expectedOutputFolder := path.Join(examplesExpectedOutputBasePath, file.Name())
+		for _, missingKeyAction := range config.ALL_MISSING_KEY_ACTIONS {
+			if file.IsDir() {
+				templateFolder := path.Join(examplesBasePath, file.Name())
+				outputFolder := path.Join(outputBasePath, file.Name())
+				varFile := path.Join(examplesVarFilesBasePath, file.Name(), "vars.yml")
+				expectedOutputFolder := path.Join(examplesExpectedOutputBasePath, file.Name())
 
-			command := fmt.Sprintf("boilerplate --template-folder %s --output-folder %s --var-file %s --non-interactive", templateFolder, outputFolder, varFile)
-			err := app.Run(strings.Split(command, " "))
-			assert.Nil(t, err, "boilerplate exited with an error when trying to generate example %s: %s", templateFolder, err)
-			assertDirectoriesEqual(t, expectedOutputFolder, outputFolder)
+				command := fmt.Sprintf("boilerplate --template-folder %s --output-folder %s --var-file %s --non-interactive --missing-key-action %s", templateFolder, outputFolder, varFile, missingKeyAction.String())
+				err := app.Run(strings.Split(command, " "))
+				assert.Nil(t, err, "boilerplate exited with an error when trying to generate example %s: %s", templateFolder, err)
+				assertDirectoriesEqual(t, expectedOutputFolder, outputFolder)
+			}
 		}
 	}
 }

--- a/templates/template_processor.go
+++ b/templates/template_processor.go
@@ -14,43 +14,43 @@ import (
 
 // Copy all the files and folders in templateFolder to outputFolder, passing text files through the Go template engine
 // with the given set of variables as the data.
-func ProcessTemplateFolder(templateFolder string, outputFolder string, variables map[string]string) error {
-	util.Logger.Printf("Processing templates in %s and outputting generated files to %s", templateFolder, outputFolder)
+func ProcessTemplateFolder(options *config.BoilerplateOptions, variables map[string]string) error {
+	util.Logger.Printf("Processing templates in %s and outputting generated files to %s", options.TemplateFolder, options.OutputFolder)
 
-	if err := os.MkdirAll(outputFolder, 0777); err != nil {
+	if err := os.MkdirAll(options.OutputFolder, 0777); err != nil {
 		return errors.WithStackTrace(err)
 	}
 
-	return filepath.Walk(templateFolder, func(path string, info os.FileInfo, err error) error {
-		if shouldSkipPath(path, templateFolder) {
+	return filepath.Walk(options.TemplateFolder, func(path string, info os.FileInfo, err error) error {
+		if shouldSkipPath(path, options) {
 			util.Logger.Printf("Skipping %s", path)
 			return nil
 		} else if util.IsDir(path) {
-			return createOutputDir(path, templateFolder, outputFolder)
+			return createOutputDir(path, options)
 		} else {
-			return processFile(path, templateFolder, outputFolder, variables)
+			return processFile(path, options, variables)
 		}
 	})
 }
 
 // Copy the given path, which is in the folder templateFolder, to the outputFolder, passing it through the Go template
 // engine with the given set of variables as the data if it's a text file.
-func processFile(path string, templateFolder string, outputFolder string, variables map[string]string) error {
+func processFile(path string, options *config.BoilerplateOptions, variables map[string]string) error {
 	isText, err := util.IsTextFile(path)
 	if err != nil {
 		return err
 	}
 
 	if isText {
-		return processTemplate(path, templateFolder, outputFolder, variables)
+		return processTemplate(path, options, variables)
 	} else {
-		return copyFile(path, templateFolder, outputFolder, variables)
+		return copyFile(path, options, variables)
 	}
 }
 
 // Create the given directory, which is in templateFolder, in the given outputFolder
-func createOutputDir(dir string, templateFolder string, outputFolder string) error {
-	destination, err := outPath(dir, templateFolder, outputFolder)
+func createOutputDir(dir string, options *config.BoilerplateOptions) error {
+	destination, err := outPath(dir, options.TemplateFolder, options.OutputFolder)
 	if err != nil {
 		return err
 	}
@@ -80,9 +80,9 @@ func outPath(file string, templateFolder string, outputFolder string) (string, e
 	return path.Join(outputFolder, relPath), nil
 }
 
-// Copy the given file, which is in templateFolder, to outputFolder
-func copyFile(file string, templateFolder string, outputFolder string, variables map[string]string) error {
-	destination, err := outPath(file, templateFolder, outputFolder)
+// Copy the given file, which is in options.TemplateFolder, to options.OutputFolder
+func copyFile(file string, options *config.BoilerplateOptions, variables map[string]string) error {
+	destination, err := outPath(file, options.TemplateFolder, options.OutputFolder)
 	if err != nil {
 		return err
 	}
@@ -93,8 +93,8 @@ func copyFile(file string, templateFolder string, outputFolder string, variables
 
 // Run the template at templatePath, which is in templateFolder, through the Go template engine with the given
 // variables as data and write the result to outputFolder
-func processTemplate(templatePath string, templateFolder string, outputFolder string, variables map[string]string) error {
-	destination, err := outPath(templatePath, templateFolder, outputFolder)
+func processTemplate(templatePath string, options *config.BoilerplateOptions, variables map[string]string) error {
+	destination, err := outPath(templatePath, options.TemplateFolder, options.OutputFolder)
 	if err != nil {
 		return err
 	}
@@ -105,7 +105,7 @@ func processTemplate(templatePath string, templateFolder string, outputFolder st
 		return errors.WithStackTrace(err)
 	}
 
-	out, err := renderTemplate(templatePath, string(bytes), variables)
+	out, err := renderTemplate(templatePath, string(bytes), variables, options.OnMissingKey)
 	if err != nil {
 		return err
 	}
@@ -114,20 +114,22 @@ func processTemplate(templatePath string, templateFolder string, outputFolder st
 }
 
 // Return true if this is a path that should not be copied
-func shouldSkipPath(path string, templateFolder string) bool {
-	return path == templateFolder || path == config.BoilerPlateConfigPath(templateFolder)
+func shouldSkipPath(path string, options *config.BoilerplateOptions) bool {
+	return path == options.TemplateFolder || path == config.BoilerPlateConfigPath(options.TemplateFolder)
 }
 
 // Render the template at templatePath, with contents templateContents, using the Go template engine, passing in the
 // given variables as data.
-func renderTemplate(templatePath string, templateContents string, variables map[string]string) (string, error) {
-	tmpl, err := template.New(templatePath).Funcs(CreateTemplateHelpers(templatePath)).Parse(templateContents)
+func renderTemplate(templatePath string, templateContents string, variables map[string]string, missingKeyAction config.MissingKeyAction) (string, error) {
+	template := template.New(templatePath).Funcs(CreateTemplateHelpers(templatePath)).Option("missingkey=" + missingKeyAction.String())
+
+	parsedTemplate, err := template.Parse(templateContents)
 	if err != nil {
 		return "", errors.WithStackTrace(err)
 	}
 
 	var output bytes.Buffer
-	if err := tmpl.Execute(&output, variables); err != nil {
+	if err := parsedTemplate.Execute(&output, variables); err != nil {
 		return "", errors.WithStackTrace(err)
 	}
 


### PR DESCRIPTION
This PR adds a new flag to boilerplate called `missing-key-action`. This flag determines what boilerplate will do if a template references a variable that is not defined:

* `error` (default): exit with an error. Making this the default helps to catch a lot of bugs and typos in your templates.
* `invalid`: render the text `<no value>`. 
* `zero`: render the zero value of the variable. For now, this will always be an empty string, but if we support types for variables, it will be different for each type.