### PR TITLE
Arithmetic

### DIFF
--- a/_docs/README.md
+++ b/_docs/README.md
@@ -288,10 +288,10 @@ in any of your templates using the syntax `{{"{{"}}.Title{{"}}"}}`.
 Your templates have access to all the standard functionality in [Go Template](https://golang.org/pkg/text/template/),
 including conditionals, loops, and functions. Boilerplate also includes several custom helpers that you can access:
 
-1. `snippet <PATH> [NAME]`: Returns the contents of the file at `PATH` as a string. If you specify the second argument,
-   `NAME`, only the contents of the snippet with that name will be returned. A snippet is any text in the file
-   surrounded by a line on each side of the format "boilerplate-snippet: NAME" (typically using the comment syntax for
-   the language). For example, here is how you could define a snippet named "foo" in a Java file:
+* `snippet <PATH> [NAME]`: Returns the contents of the file at `PATH` as a string. If you specify the second argument,
+  `NAME`, only the contents of the snippet with that name will be returned. A snippet is any text in the file
+  surrounded by a line on each side of the format "boilerplate-snippet: NAME" (typically using the comment syntax for
+  the language). For example, here is how you could define a snippet named "foo" in a Java file:
 
    ```java
    String str = "this is not part of the snippet";
@@ -301,22 +301,28 @@ including conditionals, loops, and functions. Boilerplate also includes several 
    return str2;
    // boilerplate-snippet: foo
    ```
-1. `downcase STRING`: Convert `STRING` to lower case. E.g. "FOO" becomes "foo".
-1. `upcase STRING`: Convert `STRING` to upper case. E.g. "foo" becomes "FOO".
-1. `capitalize STRING`: Capitalize the first letter of each word in `STRING`. E.g. "foo bar baz" becomes "Foo Bar Baz".
-1. `replace OLD NEW`: Replace the first occurrence of `OLD` with `NEW`. This is a literal replace, not regex.
-1. `replaceAll OLD NEW`: Replace all occurrences of `OLD` with `NEW`. This is a literal replace, not regex.
-1. `trim STRING`: Remove leading and trailing whitespace from `STRING`.
-1. `round FLOAT`: Round `FLOAT` to the nearest integer. E.g. 1.5 becomes 2.
-1. `ceil FLOAT`: Round up `FLOAT` to the nearest integer. E.g. 1.5 becomes 2.
-1. `floor FLOAT`: Round down `FLOAT` to the nearest integer. E.g. 1.5 becomes 1.
-1. `dasherize STRING`: Convert `STRING` to a lower case string separated by dashes. E.g. "foo Bar baz" becomes
+* `downcase STRING`: Convert `STRING` to lower case. E.g. "FOO" becomes "foo".
+* `upcase STRING`: Convert `STRING` to upper case. E.g. "foo" becomes "FOO".
+* `capitalize STRING`: Capitalize the first letter of each word in `STRING`. E.g. "foo bar baz" becomes "Foo Bar Baz".
+* `replace OLD NEW`: Replace the first occurrence of `OLD` with `NEW`. This is a literal replace, not regex.
+* `replaceAll OLD NEW`: Replace all occurrences of `OLD` with `NEW`. This is a literal replace, not regex.
+* `trim STRING`: Remove leading and trailing whitespace from `STRING`.
+* `round FLOAT`: Round `FLOAT` to the nearest integer. E.g. 1.5 becomes 2.
+* `ceil FLOAT`: Round up `FLOAT` to the nearest integer. E.g. 1.5 becomes 2.
+* `floor FLOAT`: Round down `FLOAT` to the nearest integer. E.g. 1.5 becomes 1.
+* `dasherize STRING`: Convert `STRING` to a lower case string separated by dashes. E.g. "foo Bar baz" becomes
    "foo-bar-baz".
-1. `snakeCase STRING`: Convert `STRING` to a lower case string separated by underscores. E.g. "foo Bar baz" becomes
+* `snakeCase STRING`: Convert `STRING` to a lower case string separated by underscores. E.g. "foo Bar baz" becomes
    "foo_bar_baz".
-1. `camelCase STRING`: Convert `STRING` to a camel case string. E.g. "foo Bar baz" becomes "FooBarBaz".
-1. `camelCaseLower STRING`: Convert `STRING` to a camel case string where the first letter is lower case. E.g.
+* `camelCase STRING`: Convert `STRING` to a camel case string. E.g. "foo Bar baz" becomes "FooBarBaz".
+* `camelCaseLower STRING`: Convert `STRING` to a camel case string where the first letter is lower case. E.g.
    "foo Bar baz" becomes "fooBarBaz".
+* `plus FLOAT FLOAT`: Add the two numbers.
+* `minus FLOAT FLOAT`: Subtract the two numbers.
+* `times FLOAT FLOAT`: Multiply the two numbers.
+* `divide FLOAT FLOAT`: Divide the two numbers.
+* `slice START END INCREMENT`: Generate a slice from START to END, incrementing by INCREMENT. This provides a simple
+  way to do a for-loop over a range of numbers.
 
 ## Alternative project generators
 

--- a/_docs/README.md
+++ b/_docs/README.md
@@ -317,10 +317,11 @@ including conditionals, loops, and functions. Boilerplate also includes several 
 * `camelCase STRING`: Convert `STRING` to a camel case string. E.g. "foo Bar baz" becomes "FooBarBaz".
 * `camelCaseLower STRING`: Convert `STRING` to a camel case string where the first letter is lower case. E.g.
    "foo Bar baz" becomes "fooBarBaz".
-* `plus FLOAT FLOAT`: Add the two numbers.
-* `minus FLOAT FLOAT`: Subtract the two numbers.
-* `times FLOAT FLOAT`: Multiply the two numbers.
-* `divide FLOAT FLOAT`: Divide the two numbers.
+* `plus NUM NUM`: Add the two numbers.
+* `minus NUM NUM`: Subtract the two numbers.
+* `times NUM NUM`: Multiply the two numbers.
+* `divide NUM NUM`: Divide the two numbers.
+* `mod INT INT`: Return the remainder of dividing the two numbers.
 * `slice START END INCREMENT`: Generate a slice from START to END, incrementing by INCREMENT. This provides a simple
   way to do a for-loop over a range of numbers.
 

--- a/examples/docs/README.md
+++ b/examples/docs/README.md
@@ -18,3 +18,20 @@ Here is how to use the `snippet` helper to embed files or parts of files from so
 ```html
 {{snippet "../website/index.html"}}
 ```
+
+## Arithmetic
+
+Here is how you can use the arithmetic helpers to create a numbered list:
+
+{{ with $index := "0" -}}
+{{plus $index 1}}. Item
+{{plus $index 2}}. Item
+{{plus $index 3}}. Item
+{{- end }}
+
+And here is another way to do it using the slice helper:
+
+{{ range $i := (slice 1 4 1) -}}
+{{$i}}. Item
+{{ end -}}
+

--- a/integration-tests/examples_test.go
+++ b/integration-tests/examples_test.go
@@ -52,7 +52,7 @@ func TestExamples(t *testing.T) {
 // takes a lot of code. Why waste time on that when this functionality is already nicely implemented in the Unix/Linux
 // "diff" command? We shell out to that command at test time.
 func assertDirectoriesEqual(t *testing.T, folderWithExpectedContents string, folderWithActualContents string) {
-	cmd := exec.Command("diff", "-u", folderWithExpectedContents, folderWithActualContents)
+	cmd := exec.Command("diff", "-r", "-u", folderWithExpectedContents, folderWithActualContents)
 
 	bytes, err := cmd.Output()
 	output := string(bytes)

--- a/templates/template_processor_test.go
+++ b/templates/template_processor_test.go
@@ -95,6 +95,11 @@ func TestRenderTemplate(t *testing.T) {
 		{"Snake case test: {{ .Foo | snakeCase }}", map[string]string{"Foo": "foo BAR baz!"}, config.ExitWithError, "", "Snake case test: foo_bar_baz"},
 		{"Camel case test: {{ .Foo | camelCase }}", map[string]string{"Foo": "foo BAR baz!"}, config.ExitWithError, "", "Camel case test: FooBARBaz"},
 		{"Camel case lower test: {{ .Foo | camelCaseLower }}", map[string]string{"Foo": "foo BAR baz!"}, config.ExitWithError, "", "Camel case lower test: fooBARBaz"},
+		{"Plus test: {{ plus .Foo .Bar }}", map[string]string{"Foo": "5", "Bar": "3"}, config.ExitWithError, "", "Plus test: 8"},
+		{"Minus test: {{ minus .Foo .Bar }}", map[string]string{"Foo": "5", "Bar": "3"}, config.ExitWithError, "", "Minus test: 2"},
+		{"Times test: {{ times .Foo .Bar }}", map[string]string{"Foo": "5", "Bar": "3"}, config.ExitWithError, "", "Times test: 15"},
+		{"Divide test: {{ divide .Foo .Bar | printf \"%1.5f\" }}", map[string]string{"Foo": "5", "Bar": "3"}, config.ExitWithError, "", "Divide test: 1.66667"},
+		{"Slice test: {{ slice 0 5 1 }}", map[string]string{}, config.ExitWithError, "", "Slice test: [0 1 2 3 4]"},
 		{"Filter chain test: {{ .Foo | downcase | replaceAll \" \" \"\" }}", map[string]string{"Foo": "foo BAR baz!"}, config.ExitWithError, "", "Filter chain test: foobarbaz!"},
 	}
 

--- a/templates/template_processor_test.go
+++ b/templates/template_processor_test.go
@@ -99,6 +99,7 @@ func TestRenderTemplate(t *testing.T) {
 		{"Minus test: {{ minus .Foo .Bar }}", map[string]string{"Foo": "5", "Bar": "3"}, config.ExitWithError, "", "Minus test: 2"},
 		{"Times test: {{ times .Foo .Bar }}", map[string]string{"Foo": "5", "Bar": "3"}, config.ExitWithError, "", "Times test: 15"},
 		{"Divide test: {{ divide .Foo .Bar | printf \"%1.5f\" }}", map[string]string{"Foo": "5", "Bar": "3"}, config.ExitWithError, "", "Divide test: 1.66667"},
+		{"Mod test: {{ mod .Foo .Bar }}", map[string]string{"Foo": "5", "Bar": "3"}, config.ExitWithError, "", "Mod test: 2"},
 		{"Slice test: {{ slice 0 5 1 }}", map[string]string{}, config.ExitWithError, "", "Slice test: [0 1 2 3 4]"},
 		{"Filter chain test: {{ .Foo | downcase | replaceAll \" \" \"\" }}", map[string]string{"Foo": "foo BAR baz!"}, config.ExitWithError, "", "Filter chain test: foobarbaz!"},
 	}

--- a/test-fixtures/examples-expected-output/dependencies-recursive/dependencies/docs/README.md
+++ b/test-fixtures/examples-expected-output/dependencies-recursive/dependencies/docs/README.md
@@ -26,3 +26,17 @@ Here is how to use the `snippet` helper to embed files or parts of files from so
   </body>
 </html>
 ```
+
+## Arithmetic
+
+Here is how you can use the arithmetic helpers to create a numbered list:
+
+1. Item
+2. Item
+3. Item
+
+And here is another way to do it using the slice helper:
+
+1. Item
+2. Item
+3. Item

--- a/test-fixtures/examples-expected-output/dependencies/docs/README.md
+++ b/test-fixtures/examples-expected-output/dependencies/docs/README.md
@@ -26,3 +26,17 @@ Here is how to use the `snippet` helper to embed files or parts of files from so
   </body>
 </html>
 ```
+
+## Arithmetic
+
+Here is how you can use the arithmetic helpers to create a numbered list:
+
+1. Item
+2. Item
+3. Item
+
+And here is another way to do it using the slice helper:
+
+1. Item
+2. Item
+3. Item

--- a/test-fixtures/examples-expected-output/docs/README.md
+++ b/test-fixtures/examples-expected-output/docs/README.md
@@ -26,3 +26,17 @@ Here is how to use the `snippet` helper to embed files or parts of files from so
   </body>
 </html>
 ```
+
+## Arithmetic
+
+Here is how you can use the arithmetic helpers to create a numbered list:
+
+1. Item
+2. Item
+3. Item
+
+And here is another way to do it using the slice helper:
+
+1. Item
+2. Item
+3. Item


### PR DESCRIPTION
This PR adds some basic arithmetic and loop helpers to boilerplate. This will make it a bit easier to perform basic math, loops, etc. 

I’ve also updated the existing math helpers to take any type of value and try to convert it to an int, rather than explicitly requiring an int or float64 or a specific type. When working inside a template, you often have a mix of strings, ints, floats, etc and having to do specific type conversions is not usually an option.