### PR TITLE
Improve the prompt for variable values

### DIFF
--- a/config/variables.go
+++ b/config/variables.go
@@ -81,7 +81,16 @@ func getVariableFromVars(variable Variable, options *BoilerplateOptions) (string
 
 // Get the value for the given variable by prompting the user
 func getVariableFromUser(variable Variable, options *BoilerplateOptions) (string, error) {
-	value, err := util.PromptUserForInput(formatPrompt(variable, options))
+	util.BRIGHT_GREEN.Printf("\n%s\n", variable.Description())
+	if variable.Prompt != "" {
+		fmt.Printf("  %s\n", variable.Prompt)
+	}
+	if variable.Default != "" {
+		fmt.Printf("  (default: %s)\n", variable.Default)
+	}
+	fmt.Println()
+
+	value, err := util.PromptUserForInput("  Enter a value")
 	if err != nil {
 		return "", err
 	}
@@ -93,20 +102,6 @@ func getVariableFromUser(variable Variable, options *BoilerplateOptions) (string
 	} else {
 		return value, nil
 	}
-}
-
-// Return the text that prompts the user to enter a value for the given variable
-func formatPrompt(variable Variable, options *BoilerplateOptions) string {
-	prompt := fmt.Sprintf("Enter a value for variable '%s'", variable.Description())
-
-	if variable.Prompt != "" {
-		prompt = variable.Prompt
-	}
-	if variable.Default != "" {
-		prompt = fmt.Sprintf("%s (default: '%s')", prompt, variable.Default)
-	}
-
-	return prompt
 }
 
 // Parse a list of NAME=VALUE pairs into a map.

--- a/config/variables_test.go
+++ b/config/variables_test.go
@@ -8,54 +8,6 @@ import (
 	"gopkg.in/yaml.v2"
 )
 
-func TestFormatPrompt(t *testing.T) {
-	t.Parallel()
-
-	variable := Variable{Name: "foo"}
-	options := &BoilerplateOptions{}
-
-	actual := formatPrompt(variable, options)
-	expected := "Enter a value for variable 'foo'"
-
-	assert.Equal(t, expected, actual)
-}
-
-func TestFormatPromptWithDefault(t *testing.T) {
-	t.Parallel()
-
-	variable := Variable{Name: "foo", Default: "bar"}
-	options := &BoilerplateOptions{}
-
-	actual := formatPrompt(variable, options)
-	expected := "Enter a value for variable 'foo' (default: 'bar')"
-
-	assert.Equal(t, expected, actual)
-}
-
-func TestFormatPromptWithCustomPrompt(t *testing.T) {
-	t.Parallel()
-
-	variable := Variable{Name: "foo", Prompt: "custom"}
-	options := &BoilerplateOptions{}
-
-	actual := formatPrompt(variable, options)
-	expected := "custom"
-
-	assert.Equal(t, expected, actual)
-}
-
-func TestFormatPromptWithCustomPromptAndDefault(t *testing.T) {
-	t.Parallel()
-
-	variable := Variable{Name: "foo", Prompt: "custom", Default: "bar"}
-	options := &BoilerplateOptions{}
-
-	actual := formatPrompt(variable, options)
-	expected := "custom (default: 'bar')"
-
-	assert.Equal(t, expected, actual)
-}
-
 func TestGetVariableFromVarsEmptyVars(t *testing.T) {
 	t.Parallel()
 

--- a/glide.lock
+++ b/glide.lock
@@ -1,12 +1,20 @@
-hash: 1cf5730f4c491e4b1701021fcd89835eb6c58df1f8aa7dca1e0abfe3b0ec9e7e
-updated: 2016-06-12T00:18:16.347783632+02:00
+hash: 335449dc7be6aa47619fd5403abc52e973ac16578e53b8d4dd56819cce812896
+updated: 2016-09-16T17:38:33.651850014+01:00
 imports:
+- name: github.com/BurntSushi/toml
+  version: 99064174e013895bbd9b025c31100bd1d9b590ca
 - name: github.com/davecgh/go-spew
   version: 5215b55f46b2b919f50a1df0eaa5886afe4e3b3d
   subpackages:
   - spew
+- name: github.com/fatih/color
+  version: 87d4004f2ab62d0d255e0a38f1680aa534549fe3
 - name: github.com/go-errors/errors
   version: a41850380601eeb43f4350f7d17c6bbd8944aaf8
+- name: github.com/mattn/go-colorable
+  version: ed8eb9e318d7a84ce5915b495b7d35e0cfe7b5a8
+- name: github.com/mattn/go-isatty
+  version: 66b8e73f3f5cda9f96b69efd03dd3d7fc4a5cdb8
 - name: github.com/pmezard/go-difflib
   version: d8ed2627bdf02c080bf22230dbb337003b7aba2d
   subpackages:
@@ -14,13 +22,19 @@ imports:
 - name: github.com/stretchr/objx
   version: cbeaeb16a013161a98496fad62933b1d21786672
 - name: github.com/stretchr/testify
-  version: 8d64eb7173c7753d6419fd4a9caf057398611364
+  version: d77da356e56a7428ad25149ca77381849a6a5232
   subpackages:
   - assert
   - http
   - mock
 - name: github.com/urfave/cli
-  version: e5bef42c62aa7d25aba4880dc02b7624f01e9e19
+  version: 61f519fe5e57c2518c03627b194899a105838eba
+- name: golang.org/x/sys
+  version: 30de6d19a3bd89a5f38ae4028e23aaa5582648af
+  subpackages:
+  - unix
+- name: gopkg.in/urfave/cli.v1
+  version: a14d7d367bc02b1f57d88de97926727f2d936387
 - name: gopkg.in/yaml.v2
-  version: a83829b6f1293c91addabc89d0571c246397bbf4
+  version: 31c299268d302dd0aa9a0dcf765a3d58971ac83f
 devImports: []

--- a/glide.yaml
+++ b/glide.yaml
@@ -7,3 +7,4 @@ import:
 - package: github.com/stretchr/testify/assert
 - package: github.com/go-errors/errors
 - package: gopkg.in/yaml.v2
+- package: github.com/fatih/color

--- a/util/prompt.go
+++ b/util/prompt.go
@@ -6,11 +6,14 @@ import (
 	"os"
 	"bufio"
 	"github.com/gruntwork-io/boilerplate/errors"
+	"github.com/fatih/color"
 )
+
+var BRIGHT_GREEN = color.New(color.FgHiGreen, color.Bold)
 
 // Prompt the user for text in the CLI. Returns the text entered by the user.
 func PromptUserForInput(prompt string) (string, error) {
-	fmt.Print(fmt.Sprintf("%s: ", prompt))
+	BRIGHT_GREEN.Print(fmt.Sprintf("%s: ", prompt))
 	reader := bufio.NewReader(os.Stdin)
 
 	text, err := reader.ReadString('\n')


### PR DESCRIPTION
This PR improves the way the boilerplate prompts the user for variable values. I largely copied the style used by Terraform. See the screenshot below.

<img width="916" alt="screen shot 2016-09-16 at 5 46 53 pm" src="https://cloud.githubusercontent.com/assets/711908/18593964/a7f298f6-7c35-11e6-93a1-cc6de953c3fb.png">
