### PR TITLE
Add support for interpolation in path names

### DIFF
--- a/_docs/README.md
+++ b/_docs/README.md
@@ -281,7 +281,10 @@ non-binary file through the [Go Template](https://golang.org/pkg/text/template) 
 data structure.
 
 For example, if you had a variable called `Title` in your `boilerplate.yml` file, then you could access that variable
-in any of your templates using the syntax `{{"{{"}}.Title{{"}}"}}`.
+in any of your templates using the syntax `{{"{{"}}.Title{{"}}"}}`. You can even use Go template syntax and boilerplate
+variables in the names of your files and folders. For example, you could create a file called
+`{{"{{"}}.Title{{"}}"}}.txt` and if the user ran `boilerplate` and "foo" as the `Title`, you'd end up with the file
+`foo.txt`.
 
 #### Template helpers
 

--- a/examples/docs/boilerplate.yml
+++ b/examples/docs/boilerplate.yml
@@ -2,3 +2,11 @@ variables:
   - name: Title
 
   - name: Version
+
+  - name: SubFolderName
+    prompt: This variable will be used to create the name of a subfolder dynamically
+    default: example folder
+
+  - name: FileName
+    prompt: This variable will be used to create the name of a file dynamically
+    default: my example file

--- a/examples/docs/interpolated-folder-{{.SubFolderName|dasherize}}/{{.FileName|snakeCase}}.py
+++ b/examples/docs/interpolated-folder-{{.SubFolderName|dasherize}}/{{.FileName|snakeCase}}.py
@@ -1,0 +1,1 @@
+# This file and its parent folder both show an example of using Go template syntax and boilerplate variables in their names

--- a/templates/template_processor_test.go
+++ b/templates/template_processor_test.go
@@ -17,18 +17,26 @@ func TestOutPath(t *testing.T) {
 		file	       string
 		templateFolder string
 		outputFolder   string
+		variables      map[string]string
 		expected       string
 	}{
-		{"template-folder/foo.txt", "template-folder", "output-folder", "output-folder/foo.txt"},
-		{"foo/bar/template-folder/foo.txt", "foo/bar/template-folder", "output-folder", "output-folder/foo.txt"},
-		{"template-folder/foo.txt", pwd + "/template-folder", "output-folder", "output-folder/foo.txt"},
-		{"template-folder/foo/bar/baz.txt", pwd + "/template-folder", "output-folder", "output-folder/foo/bar/baz.txt"},
+		{"template-folder/foo.txt", "template-folder", "output-folder", map[string]string{}, "output-folder/foo.txt"},
+		{"foo/bar/template-folder/foo.txt", "foo/bar/template-folder", "output-folder", map[string]string{}, "output-folder/foo.txt"},
+		{"template-folder/foo.txt", pwd + "/template-folder", "output-folder", map[string]string{}, "output-folder/foo.txt"},
+		{"template-folder/foo/bar/baz.txt", pwd + "/template-folder", "output-folder", map[string]string{}, "output-folder/foo/bar/baz.txt"},
+		{"template-folder/{{.Foo}}.txt", pwd + "/template-folder", "output-folder", map[string]string{"Foo": "foo"}, "output-folder/foo.txt"},
+		{"template-folder/{{.Foo | dasherize}}.txt", pwd + "/template-folder", "output-folder", map[string]string{"Foo": "Foo Bar Baz"}, "output-folder/foo-bar-baz.txt"},
 	}
 
 	for _, testCase := range testCases {
-		actual, err := outPath(testCase.file, testCase.templateFolder, testCase.outputFolder)
-		assert.Nil(t, err)
-		assert.Equal(t, testCase.expected, actual)
+		options := config.BoilerplateOptions{
+			TemplateFolder: testCase.templateFolder,
+			OutputFolder: testCase.outputFolder,
+			NonInteractive: true,
+		}
+		actual, err := outPath(testCase.file, &options, testCase.variables)
+		assert.Nil(t, err, "Got unexpected error (file = %s, templateFolder = %s, outputFolder = %s, and variables = %s): %v", testCase.file, testCase.templateFolder, testCase.outputFolder, testCase.variables, err)
+		assert.Equal(t, testCase.expected, actual, "(file = %s, templateFolder = %s, outputFolder = %s, and variables = %s)", testCase.file, testCase.templateFolder, testCase.outputFolder, testCase.variables)
 	}
 }
 

--- a/test-fixtures/examples-expected-output/dependencies-recursive/dependencies/docs/interpolated-folder-example-folder/my_example_file.py
+++ b/test-fixtures/examples-expected-output/dependencies-recursive/dependencies/docs/interpolated-folder-example-folder/my_example_file.py
@@ -1,0 +1,1 @@
+# This file and its parent folder both show an example of using Go template syntax and boilerplate variables in their names

--- a/test-fixtures/examples-expected-output/dependencies/docs/interpolated-folder-example-folder/my_example_file.py
+++ b/test-fixtures/examples-expected-output/dependencies/docs/interpolated-folder-example-folder/my_example_file.py
@@ -1,0 +1,1 @@
+# This file and its parent folder both show an example of using Go template syntax and boilerplate variables in their names

--- a/test-fixtures/examples-expected-output/docs/interpolated-folder-example-folder/my_example_file.py
+++ b/test-fixtures/examples-expected-output/docs/interpolated-folder-example-folder/my_example_file.py
@@ -1,0 +1,1 @@
+# This file and its parent folder both show an example of using Go template syntax and boilerplate variables in their names


### PR DESCRIPTION
This PR updates `boilerplate` so that you can use Go template syntax and boilerplate variables in the names of files and folders. 

This is very handy in cases where the paths are determined dynamically. For example, if you were using `boilerplate` to generate a Java project, your template folder could contain the path `com/{{.PackageName}}/MyFactory.java`. If you run `boilerplate` against this template folder and enter
"gruntwork" as the `PackageName`, you'd end up with the file `com/gruntwork/MyFactory.java`.