### PR TITLE
Exit with an error if the boilerplate.yml file is missing

### DIFF
--- a/_docs/README.md
+++ b/_docs/README.md
@@ -127,6 +127,9 @@ The `boilerplate` binary supports the following options:
 * `--missing-key-action ACTION` (optional): What to do if a template looks up a variable that is not defined. Must
   be one of: `invalid` (render the text "<no value>"), `zero` (render the zero value for the variable), or `error`
   (return an error and exit immediately). Default: `error`.
+* `--missing-config-action ACTION` (optional): What to do if a template folder does not have a `boilerplate.yml` file.
+  Must be one of: `exit` (return an error and exit immediately) or `ignore` (log a warning and process the template
+  folder without any variables). Default: `exit`.
 * `--help`: Show the help text and exit.
 * `--version`: Show the version and exit.
 
@@ -153,7 +156,8 @@ boilerplate --template-folder ~/templates --output-folder ~/output --var-file va
 #### The boilerplate.yml file
 
 The `boilerplate.yml` file is used to configure `boilerplate`. The file is optional. If you don't specify it, you can
-still use Go templating in your templates, but no variables or dependencies will be available.
+still use Go templating in your templates so long as you specify the `--missing-config-action ignore` option, but no
+variables or dependencies will be available.
 
 `boilerplate.yml` uses the following syntax:
 

--- a/cli/boilerplate_cli.go
+++ b/cli/boilerplate_cli.go
@@ -79,6 +79,10 @@ func CreateBoilerplateCli(version string) *cli.App {
 			Name: config.OPT_MISSING_KEY_ACTION,
 			Usage: fmt.Sprintf("What `ACTION` to take if a template looks up a variable that is not defined. Must be one of: %s. Default: %s.", config.ALL_MISSING_KEY_ACTIONS, config.DEFAULT_MISSING_KEY_ACTION),
 		},
+		cli.StringFlag{
+			Name: config.OPT_MISSING_CONFIG_ACTION,
+			Usage: fmt.Sprintf("What `ACTION` to take if a the template folder does not contain a boilerplate.yml file. Must be one of: %s. Default: %s.", config.ALL_MISSING_CONFIG_ACTIONS, config.DEFAULT_MISSING_CONFIG_ACTION),
+		},
 	}
 
 	return app
@@ -116,11 +120,21 @@ func parseOptions(cliContext *cli.Context) (*config.BoilerplateOptions, error) {
 		}
 	}
 
+	missingConfigAction := config.DEFAULT_MISSING_CONFIG_ACTION
+	missingConfigActionValue := cliContext.String(config.OPT_MISSING_CONFIG_ACTION)
+	if missingConfigActionValue != "" {
+		missingConfigAction, err = config.ParseMissingConfigAction(missingConfigActionValue)
+		if err != nil {
+			return nil, err
+		}
+	}
+
 	options := &config.BoilerplateOptions{
 		TemplateFolder: cliContext.String(config.OPT_TEMPLATE_FOLDER),
 		OutputFolder: cliContext.String(config.OPT_OUTPUT_FOLDER),
 		NonInteractive: cliContext.Bool(config.OPT_NON_INTERACTIVE),
 		OnMissingKey: missingKeyAction,
+		OnMissingConfig: missingConfigAction,
 		Vars: vars,
 	}
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -6,6 +6,7 @@ import (
 	"reflect"
 	"gopkg.in/yaml.v2"
 	"github.com/gruntwork-io/boilerplate/errors"
+	"path"
 )
 
 func TestParseBoilerplateConfigEmpty(t *testing.T) {
@@ -332,7 +333,18 @@ func TestLoadBoilerPlateConfigFullConfig(t *testing.T) {
 func TestLoadBoilerPlateConfigNoConfig(t *testing.T) {
 	t.Parallel()
 
-	actual, err := LoadBoilerPlateConfig(&BoilerplateOptions{TemplateFolder: "../test-fixtures/config-test/no-config"})
+	templateFolder := "../test-fixtures/config-test/no-config"
+	_, err := LoadBoilerPlateConfig(&BoilerplateOptions{TemplateFolder: templateFolder})
+	expectedErr := BoilerplateConfigNotFound(path.Join(templateFolder, "boilerplate.yml"))
+
+	assert.True(t, errors.IsError(err, expectedErr), "Expected error %v but got %v", expectedErr, err)
+}
+
+func TestLoadBoilerPlateConfigNoConfigIgnore(t *testing.T) {
+	t.Parallel()
+
+	templateFolder := "../test-fixtures/config-test/no-config"
+	actual, err := LoadBoilerPlateConfig(&BoilerplateOptions{TemplateFolder: templateFolder, OnMissingConfig: Ignore})
 	expected := &BoilerplateConfig{}
 
 	assert.Nil(t, err)

--- a/integration-tests/examples_test.go
+++ b/integration-tests/examples_test.go
@@ -39,7 +39,7 @@ func TestExamples(t *testing.T) {
 				varFile := path.Join(examplesVarFilesBasePath, file.Name(), "vars.yml")
 				expectedOutputFolder := path.Join(examplesExpectedOutputBasePath, file.Name())
 
-				command := fmt.Sprintf("boilerplate --template-folder %s --output-folder %s --var-file %s --non-interactive --missing-key-action %s", templateFolder, outputFolder, varFile, missingKeyAction.String())
+				command := fmt.Sprintf("boilerplate --template-folder %s --output-folder %s --var-file %s --non-interactive --missing-key-action %s", templateFolder, outputFolder, varFile, string(missingKeyAction))
 				err := app.Run(strings.Split(command, " "))
 				assert.Nil(t, err, "boilerplate exited with an error when trying to generate example %s: %s", templateFolder, err)
 				assertDirectoriesEqual(t, expectedOutputFolder, outputFolder)

--- a/templates/template_processor.go
+++ b/templates/template_processor.go
@@ -228,7 +228,7 @@ func shouldSkipPath(path string, options *config.BoilerplateOptions) bool {
 // Render the template at templatePath, with contents templateContents, using the Go template engine, passing in the
 // given variables as data.
 func renderTemplate(templatePath string, templateContents string, variables map[string]string, missingKeyAction config.MissingKeyAction) (string, error) {
-	template := template.New(templatePath).Funcs(CreateTemplateHelpers(templatePath)).Option("missingkey=" + missingKeyAction.String())
+	template := template.New(templatePath).Funcs(CreateTemplateHelpers(templatePath)).Option("missingkey=" + string(missingKeyAction))
 
 	parsedTemplate, err := template.Parse(templateContents)
 	if err != nil {

--- a/templates/template_processor_test.go
+++ b/templates/template_processor_test.go
@@ -33,6 +33,8 @@ func TestOutPath(t *testing.T) {
 			TemplateFolder: testCase.templateFolder,
 			OutputFolder: testCase.outputFolder,
 			NonInteractive: true,
+			OnMissingKey: config.ExitWithError,
+			OnMissingConfig: config.Exit,
 		}
 		actual, err := outPath(testCase.file, &options, testCase.variables)
 		assert.Nil(t, err, "Got unexpected error (file = %s, templateFolder = %s, outputFolder = %s, and variables = %s): %v", testCase.file, testCase.templateFolder, testCase.outputFolder, testCase.variables, err)


### PR DESCRIPTION
This PR updates `boilerplate` to exit with an error if there is no `boilerplate.ml` file in the template folder. I’ve also added a flag to make this behavior configurable in case you want to use boilerplate without variables. 