### PR TITLE
Fix bug with passing lists and maps to dependencies

### DIFF
--- a/examples/dependencies-recursive/boilerplate.yml
+++ b/examples/dependencies-recursive/boilerplate.yml
@@ -26,3 +26,27 @@ dependencies:
 
         - name: Title
           description: Enter the title for the dependencies example
+
+    - name: java-project
+      template-folder: ../java-project
+      output-folder: ./java-project
+      variables:
+        - name: CompanyName
+          description: Enter the name of the company
+          type: string
+
+        - name: ExampleIntConstant
+          description: Enter the value for an integer constant in the Java file
+          type: int
+
+        - name: IncludeEnum
+          description: Should we create an example Enum in the Java file?
+          type: bool
+
+        - name: EnumNames
+          description: Enter the names of the Enums in the Java file
+          type: list
+
+        - name: ExampleMap
+          description: Enter some example values to store in a HashMap
+          type: map

--- a/test-fixtures/examples-expected-output/dependencies-recursive/java-project/com/acme/example/Example.java
+++ b/test-fixtures/examples-expected-output/dependencies-recursive/java-project/com/acme/example/Example.java
@@ -1,0 +1,12 @@
+package com.acme.example
+
+import com.google.common.collect.ImmutableMap;
+
+public class Example {
+  public static final int EXAMPLE_INT_CONSTANT = 42
+  public static final Map<> EXAMPLE_MAP = ImmutableMap.of("key1", "value1", "key2", "value2", "key3", "value3");
+
+  public enum ExampleEnum {
+    Foo, Bar, Baz
+  }
+}

--- a/test-fixtures/examples-var-files/dependencies-recursive/vars.yml
+++ b/test-fixtures/examples-var-files/dependencies-recursive/vars.yml
@@ -1,8 +1,21 @@
 Version: 0.0.3
 Title: Recursive dependencies example
+WelcomeText: Welcome!
+Description: This is a boilerplate template that shows an example of using recursive dependencies
+
 dependencies.Title: Dependencies example
 dependencies.Description: This is a boilerplate template that shows an example of using dependencies
 dependencies.website.Title: Boilerplate
 dependencies.docs.Title: Docs example
-WelcomeText: Welcome!
-Description: This is a boilerplate template that shows an example of using recursive dependencies
+
+java-project.CompanyName: acme
+java-project.ExampleIntConstant: 42
+java-project.IncludeEnum: true
+java-project.EnumNames:
+  - Foo
+  - Bar
+  - Baz
+java-project.ExampleMap:
+  key1: value1
+  key2: value2
+  key3: value3

--- a/variables/variables.go
+++ b/variables/variables.go
@@ -197,9 +197,15 @@ func UnmarshalValueForVariable(value interface{}, variable Variable) (interface{
 		if asList, isList := value.([]interface{}); isList {
 			return util.ToStringList(asList), nil
 		}
+		if asList, isList := value.([]string); isList {
+			return asList, nil
+		}
 	case Map:
 		if asMap, isMap := value.(map[interface{}]interface{}); isMap {
 			return util.ToStringMap(asMap), nil
+		}
+		if asMap, isMap := value.(map[string]string); isMap {
+			return asMap, nil
 		}
 	case Enum:
 		if asString, isString := value.(string); isString {


### PR DESCRIPTION
This PR fixes a bug where boilerplate wasn’t able to pass lists and maps properly to dependencies. I updated the automated test to catch this bug. Before the fix, the test would exit with the error “Value '[Foo Bar Baz]' is not a valid value for variable 'EnumNames' with type 'list’.” After this fix, it works correctly.

The cause is as follows. When boilerplate gets a variable from YAML, a list is represented as an `[]interface{}` and a map as `map[interface{}]interface{}`. boilerplate looks for these types and converts them to `[]string` and `map[string]string`. However, when we passed this converted value to a dependency, we were still only looking for the more generic versions `[]interface{}` and `map[interface{}]interface{}`.