### PR TITLE
The Shell helper now runs in the same directory as the template you call it in

### DIFF
--- a/_docs/README.md
+++ b/_docs/README.md
@@ -345,7 +345,9 @@ including conditionals, loops, and functions. Boilerplate also includes several 
   way to do a for-loop over a range of numbers.
 * `keys MAP`: Return a slice that contains all the keys in the given MAP. Use the built-in Go template helper `.index`
   to look up these keys in the map.
-* `shell CMD`: Execute the given shell command and render whatever that command prints to stdout.
+* `shell CMD`: Execute the given shell command and render whatever that command prints to stdout. The working directory
+  for the command will be set to the directory of the template being rendered, so you can use paths relative to the
+  file from which you are calling the `shell` helper.
 
 ## Alternative project generators
 

--- a/examples/shell/example-script.sh
+++ b/examples/shell/example-script.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# An example script that will be executed via the 'shell' command in a boilerplate template. This script simply echoes
+# back the arguments you pass to it.
+
+echo "$@"

--- a/examples/shell/hello-world.txt
+++ b/examples/shell/hello-world.txt
@@ -1,3 +1,3 @@
 Example of executing an arbitrary shell command using the shell helper:
 
-{{ shell "echo" .Text }}
+{{ shell "./example-script.sh" .Text }}

--- a/templates/template_helpers.go
+++ b/templates/template_helpers.go
@@ -63,7 +63,7 @@ func CreateTemplateHelpers(templatePath string) template.FuncMap {
 		"mod": wrapIntIntToIntFunction(func(arg1 int, arg2 int) int { return arg1 % arg2 }),
 		"slice": slice,
 		"keys": keys,
-		"shell": shell,
+		"shell": wrapWithTemplatePath(templatePath, shell),
 	}
 }
 
@@ -417,13 +417,14 @@ func keys(m map[string]string) []string {
 	return out
 }
 
-// Run the given shell command and return whatever that command wrote to stdout
-func shell(args ... string) (string, error) {
+// Run the given shell command specified in args in the working dir specified by templatePath and return stdout as a
+// string.
+func shell(templatePath string, args ... string) (string, error) {
 	if len(args) == 0 {
 		return "", errors.WithStackTrace(NoArgsPassedToShellHelper)
 	}
 
-	return util.RunShellCommandAndGetOutput(args[0], args[1:]...)
+	return util.RunShellCommandAndGetOutput(filepath.Dir(templatePath), args[0], args[1:]...)
 }
 
 // Custom errors

--- a/templates/template_helpers_test.go
+++ b/templates/template_helpers_test.go
@@ -421,7 +421,7 @@ func TestLowerFirst(t *testing.T) {
 func TestShellSuccess(t *testing.T) {
 	t.Parallel()
 
-	output, err := shell("echo", "hi")
+	output, err := shell(".", "echo", "hi")
 	assert.Nil(t, err, "Unexpected error: %v", err)
 	assert.Equal(t, "hi\n", output)
 }
@@ -429,7 +429,7 @@ func TestShellSuccess(t *testing.T) {
 func TestShellError(t *testing.T) {
 	t.Parallel()
 
-	_, err := shell("not-a-real-command")
+	_, err := shell(".", "not-a-real-command")
 	if assert.NotNil(t, err) {
 		assert.Contains(t, err.Error(), "executable file not found in $PATH", "Unexpected error message: %s", err.Error())
 	}

--- a/test-fixtures/examples-expected-output/shell/example-script.sh
+++ b/test-fixtures/examples-expected-output/shell/example-script.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# An example script that will be executed via the 'shell' command in a boilerplate template. This script simply echoes
+# back the arguments you pass to it.
+
+echo "$@"

--- a/util/shell.go
+++ b/util/shell.go
@@ -7,13 +7,14 @@ import (
 	"github.com/gruntwork-io/boilerplate/errors"
 )
 
-// Run the given shell command with the given arguments
-func RunShellCommandAndGetOutput(command string, args ... string) (string, error) {
+// Run the given shell command with the given arguments in the given working directory
+func RunShellCommandAndGetOutput(workingDir string, command string, args ... string) (string, error) {
 	Logger.Printf("Running command: %s %s", command, strings.Join(args, " "))
 
 	cmd := exec.Command(command, args...)
 
 	cmd.Stdin = os.Stdin
+	cmd.Dir = workingDir
 
 	out, err := cmd.Output()
 	if err != nil {


### PR DESCRIPTION
The `shell` helper now explicitly runs in the same folder as the file calling that helper. This makes it easier to use relative paths in the `shell` helper.