### PR TITLE
Add templateFolder and outputFolder helpers

### DIFF
--- a/_docs/README.md
+++ b/_docs/README.md
@@ -348,6 +348,8 @@ including conditionals, loops, and functions. Boilerplate also includes several 
 * `shell CMD`: Execute the given shell command and render whatever that command prints to stdout. The working directory
   for the command will be set to the directory of the template being rendered, so you can use paths relative to the
   file from which you are calling the `shell` helper.
+* `templateFolder`: Return the value of the `--template-folder` command-line option. Useful for building relative paths.
+* `outputFolder`: Return the value of the `--output-folder` command-line option. Useful for building relative paths.
 
 ## Alternative project generators
 

--- a/templates/template_helpers.go
+++ b/templates/template_helpers.go
@@ -16,6 +16,7 @@ import (
 	"unicode"
 	"github.com/gruntwork-io/boilerplate/util"
 	"sort"
+	"github.com/gruntwork-io/boilerplate/config"
 )
 
 var SNIPPET_MARKER_REGEX = regexp.MustCompile("boilerplate-snippet:\\s*(.+?)(?:\\s|$)")
@@ -40,7 +41,7 @@ var CAMEL_CASE_REGEX = regexp.MustCompile(
 type TemplateHelper func(templatePath string, args ... string) (string, error)
 
 // Create a map of custom template helpers exposed by boilerplate
-func CreateTemplateHelpers(templatePath string) template.FuncMap {
+func CreateTemplateHelpers(templatePath string, options *config.BoilerplateOptions) template.FuncMap {
 	return map[string]interface{}{
 		"snippet": wrapWithTemplatePath(templatePath, snippet),
 		"downcase": strings.ToLower,
@@ -64,6 +65,8 @@ func CreateTemplateHelpers(templatePath string) template.FuncMap {
 		"slice": slice,
 		"keys": keys,
 		"shell": wrapWithTemplatePath(templatePath, shell),
+		"templateFolder": func() string { return options.TemplateFolder },
+		"outputFolder": func() string { return options.OutputFolder },
 	}
 }
 

--- a/templates/template_processor.go
+++ b/templates/template_processor.go
@@ -171,7 +171,7 @@ func outPath(file string, options *config.BoilerplateOptions, variables map[stri
 		return "", errors.WithStackTrace(err)
 	}
 
-	interpolatedFilePath, err := renderTemplate(file, file, variables, options.OnMissingKey)
+	interpolatedFilePath, err := renderTemplate(file, file, variables, options)
 	if err != nil {
 		return "", errors.WithStackTrace(err)
 	}
@@ -214,7 +214,7 @@ func processTemplate(templatePath string, options *config.BoilerplateOptions, va
 		return errors.WithStackTrace(err)
 	}
 
-	out, err := renderTemplate(templatePath, string(bytes), variables, options.OnMissingKey)
+	out, err := renderTemplate(templatePath, string(bytes), variables, options)
 	if err != nil {
 		return err
 	}
@@ -229,11 +229,11 @@ func shouldSkipPath(path string, options *config.BoilerplateOptions) bool {
 
 // Render the template at templatePath, with contents templateContents, using the Go template engine, passing in the
 // given variables as data.
-func renderTemplate(templatePath string, templateContents string, variables map[string]interface{}, missingKeyAction config.MissingKeyAction) (string, error) {
-	option := fmt.Sprintf("missingkey=%s", string(missingKeyAction))
-	template := template.New(templatePath).Funcs(CreateTemplateHelpers(templatePath)).Option(option)
+func renderTemplate(templatePath string, templateContents string, variables map[string]interface{}, options *config.BoilerplateOptions) (string, error) {
+	option := fmt.Sprintf("missingkey=%s", string(options.OnMissingKey))
+	tmpl := template.New(templatePath).Funcs(CreateTemplateHelpers(templatePath, options)).Option(option)
 
-	parsedTemplate, err := template.Parse(templateContents)
+	parsedTemplate, err := tmpl.Parse(templateContents)
 	if err != nil {
 		return "", errors.WithStackTrace(err)
 	}

--- a/templates/template_processor_test.go
+++ b/templates/template_processor_test.go
@@ -115,11 +115,13 @@ func TestRenderTemplate(t *testing.T) {
 		{"Slice test: {{ slice 0 5 1 }}", map[string]interface{}{}, config.ExitWithError, "", "Slice test: [0 1 2 3 4]"},
 		{"Keys test: {{ keys .Map }}", map[string]interface{}{"Map": map[string]string{"key1": "value1", "key2": "value2", "key3": "value3"}}, config.ExitWithError, "", "Keys test: [key1 key2 key3]"},
 		{"Shell test: {{ shell \"echo\" .Text }}", map[string]interface{}{"Text": "Hello, World"}, config.ExitWithError, "", "Shell test: Hello, World\n"},
+		{"Template folder test: {{ templateFolder }}", map[string]interface{}{}, config.ExitWithError, "", "Template folder test: /templates"},
+		{"Output folder test: {{ outputFolder }}", map[string]interface{}{}, config.ExitWithError, "", "Output folder test: /output"},
 		{"Filter chain test: {{ .Foo | downcase | replaceAll \" \" \"\" }}", map[string]interface{}{"Foo": "foo BAR baz!"}, config.ExitWithError, "", "Filter chain test: foobarbaz!"},
 	}
 
 	for _, testCase := range testCases {
-		actualOutput, err := renderTemplate(pwd + "/template.txt", testCase.templateContents, testCase.variables, testCase.missingKeyAction)
+		actualOutput, err := renderTemplate(pwd + "/template.txt", testCase.templateContents, testCase.variables, &config.BoilerplateOptions{TemplateFolder: "/templates", OutputFolder: "/output", OnMissingKey: testCase.missingKeyAction})
 		if testCase.expectedErrorText == "" {
 			assert.Nil(t, err, "template = %s, variables = %s, missingKeyAction = %s, err = %v", testCase.templateContents, testCase.variables, testCase.missingKeyAction, err)
 			assert.Equal(t, testCase.expectedOutput, actualOutput, "template = %s, variables = %s, missingKeyAction = %s", testCase.templateContents, testCase.variables, testCase.missingKeyAction)


### PR DESCRIPTION
These two helpers are useful for building relative file paths. For example, you may want to use the `shell` helper to call `packer` to build an AMI from a Packer template. That Packer template may have been one of the outputs of the boilerplate code generation, so to build a relative file path to it, you can use the `outputFolder` helper.