### PR TITLE
Add support for hooks

### DIFF
--- a/_docs/README.md
+++ b/_docs/README.md
@@ -103,6 +103,8 @@ You can find older versions on the [Releases Page](https://github.com/gruntwork-
    helpers for common tasks such as loading the contents of another file.
 1. **Variable types**: Boilerplate variables support types, so you have first-class support for strings, ints, bools,
    lists, maps, and enums.
+1. **Scripting**: Need more power than static templates and variables? Boilerplate includes several hooks that allow 
+   you to run arbitrary scripts.  
 1. **Cross-platform**: Boilerplate is easy to install (it's a standalone binary) and works on all major platforms (Mac,
    Linux, Windows).
 
@@ -123,6 +125,7 @@ Learn more about boilerplate in the following sections:
 1. [The boilerplate.yml file](#the-boilerplate.yml-file)
 1. [Variables](#variables)
 1. [Dependencies](#dependencies)
+1. [Hooks](#hooks)
 1. [Templates](#templates)
 1. [Template helpers](#template-helpers)
 
@@ -193,6 +196,16 @@ dependencies:
         description: <DESCRIPTION>
         type: <TYPE>
         default: <DEFAULT>
+
+hooks:
+  before:
+    - command: <CMD>
+      args:
+        - <ARG>
+  after:              
+    - command: <CMD>
+      args:
+        - <ARG>
 ```
 
 Here's an example:
@@ -233,6 +246,13 @@ executing the current one. Each dependency may contain the following keys:
   description and default values here.
 
 See the [Dependencies](#dependencies) section for more info.
+
+**Hooks**: Boilerplate provides hooks to execute arbitrary shell commands. There are two types of hooks:
+
+* `before` (Optional): A list of scripts to execute before any template rendering has started.
+* `after` (Optional): A list of scripts to execute after all template rendering has completed.
+
+See the [Hooks](#hooks) section for more info.
 
 #### Variables
 
@@ -285,6 +305,35 @@ Note the following:
   prompt you for each of those variables separately from the root ones. You can also use the
   `<DEPENDENCY_NAME>.<VARIABLE_NAME>` syntax as the name of the variable with the `-var` flag and inside of a var file
   to provide a value for a variable in a dependency.
+
+#### Hooks
+
+You can specify `hooks` in `boilerplate.yml` to tell Boilerplate to execute arbitrary shell commands. 
+ 
+Note the following:
+
+* The `before` hook allows you to run scripts before Boilerplate has started rendering.
+* The `after` hook allows you to run scripts after Boilerplate has finished rendering.
+* Each hook consists of a `command` to execute (required) plus a list of `args` to pass to that command (optional).
+  Example:
+    ```yaml
+    before:
+      - command: echo
+        args:
+          - Hello
+          - World
+    ```
+* You can use Go templating syntax in both `command` and `args`. For example, you can pass Boilerplate variables to 
+  your scripts as follows:
+    ```yaml
+    before:
+      - command: foo.sh 
+        args:
+          - {{ .SomeVariable }} 
+          - {{ .AnotherVariable }}
+    ```
+* Boilerplate runs your `command` with the working directory set to the `--template-folder` option.
+* For an alternative way to execute commands, see the `shell` helper in [template helpers](#template-helpers).
 
 #### Templates
 
@@ -347,7 +396,7 @@ including conditionals, loops, and functions. Boilerplate also includes several 
   to look up these keys in the map.
 * `shell CMD`: Execute the given shell command and render whatever that command prints to stdout. The working directory
   for the command will be set to the directory of the template being rendered, so you can use paths relative to the
-  file from which you are calling the `shell` helper.
+  file from which you are calling the `shell` helper. For another way to execute commands, see [hooks](#hooks).
 * `templateFolder`: Return the value of the `--template-folder` command-line option. Useful for building relative paths.
 * `outputFolder`: Return the value of the `--output-folder` command-line option. Useful for building relative paths.
 

--- a/config/config.go
+++ b/config/config.go
@@ -24,6 +24,7 @@ const OPT_MISSING_CONFIG_ACTION = "missing-config-action"
 type BoilerplateConfig struct {
 	Variables    []variables.Variable
 	Dependencies []variables.Dependency
+	Hooks        variables.Hooks
 }
 
 // Implement the go-yaml unmarshal interface for BoilerplateConfig. We can't let go-yaml handle this itself because:
@@ -48,9 +49,15 @@ func (config *BoilerplateConfig) UnmarshalYAML(unmarshal func(interface{}) error
 		return err
 	}
 
+	hooks, err := variables.UnmarshalHooksFromBoilerplateConfigYaml(fields)
+	if err != nil {
+		return err
+	}
+
 	*config = BoilerplateConfig{
 		Variables: vars,
 		Dependencies: deps,
+		Hooks: hooks,
 	}
 	return nil
 }

--- a/examples/shell/boilerplate.yml
+++ b/examples/shell/boilerplate.yml
@@ -1,3 +1,24 @@
 variables:
   - name: Text
     description: Enter the text to display
+
+hooks:
+  before:
+    - command: echo
+      args:
+        - Running before hooks
+
+    - command: ./example-script-2.sh
+      args:
+        - "{{ .Text }} - executed via a before hook"
+        - "{{ outputFolder }}/before-hook-example.txt"
+
+  after:
+    - command: echo
+      args:
+        - Running after hooks
+
+    - command: ./example-script-2.sh
+      args:
+        - "{{ .Text }} - executed via an after hook"
+        - "{{ outputFolder }}/after-hook-example.txt"

--- a/examples/shell/example-script-2.sh
+++ b/examples/shell/example-script-2.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# An example script that will be executed via the 'shell' command in a boilerplate template. This script simply writes
+# the first argument you pass to it into the path in the second argument.
+
+echo "$1" > "$2"

--- a/test-fixtures/config-test/full-config/boilerplate.yml
+++ b/test-fixtures/config-test/full-config/boilerplate.yml
@@ -26,3 +26,12 @@ dependencies:
         description: example description
         default: default
 
+hooks:
+  before:
+    - command: echo
+      args:
+        - Hello World
+
+  after:
+    - command: foo
+    - command: bar

--- a/test-fixtures/examples-expected-output/shell/after-hook-example.txt
+++ b/test-fixtures/examples-expected-output/shell/after-hook-example.txt
@@ -1,0 +1,1 @@
+Hello, World - executed via an after hook

--- a/test-fixtures/examples-expected-output/shell/before-hook-example.txt
+++ b/test-fixtures/examples-expected-output/shell/before-hook-example.txt
@@ -1,0 +1,1 @@
+Hello, World - executed via a before hook

--- a/test-fixtures/examples-expected-output/shell/example-script-2.sh
+++ b/test-fixtures/examples-expected-output/shell/example-script-2.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# An example script that will be executed via the 'shell' command in a boilerplate template. This script simply writes
+# the first argument you pass to it into the path in the second argument.
+
+echo "$1" > "$2"

--- a/util/shell.go
+++ b/util/shell.go
@@ -23,3 +23,17 @@ func RunShellCommandAndGetOutput(workingDir string, command string, args ... str
 	}
 	return string(out), nil
 }
+
+// Run the given shell command with the given arguments in the given working directory
+func RunShellCommand(workingDir string, command string, args ... string) error {
+	Logger.Printf("Running command: %s %s", command, strings.Join(args, " "))
+
+	cmd := exec.Command(command, args...)
+
+	cmd.Stdin = os.Stdin
+	cmd.Stderr = os.Stderr
+	cmd.Stdout = os.Stdout
+	cmd.Dir = workingDir
+
+	return cmd.Run()
+}

--- a/variables/hooks.go
+++ b/variables/hooks.go
@@ -1,0 +1,99 @@
+package variables
+
+// A single hook, which is a command that is executed by boilerplate
+type Hook struct {
+	Command string
+	Args    []string
+}
+
+// All the scripts to execute as boilerplate hooks
+type Hooks struct {
+	BeforeHooks []Hook
+	AfterHooks  []Hook
+}
+
+// Given a map of key:value pairs read from a Boilerplate YAML config file of the format:
+//
+// hooks:
+//   before:
+//     - command: <CMD>
+//       args:
+//         - <ARG>
+//
+//   after:
+//     - command: <CMD>
+//       args:
+//         - <ARG>
+//
+// This method takes the data above and unmarshals it into a Hooks struct
+func UnmarshalHooksFromBoilerplateConfigYaml(fields map[string]interface{}) (Hooks, error) {
+	hookFields, err := unmarshalMapOfFields(fields, "hooks")
+	if err != nil {
+		return Hooks{}, err
+	}
+
+	beforeHooks, err := unmarshalHooksFromBoilerplateConfigYaml(hookFields, "before")
+	if err != nil {
+		return Hooks{}, err
+	}
+
+	afterHooks, err := unmarshalHooksFromBoilerplateConfigYaml(hookFields, "after")
+	if err != nil {
+		return Hooks{}, err
+	}
+
+	return Hooks{BeforeHooks: beforeHooks, AfterHooks: afterHooks}, nil
+}
+
+// Given a list of key:value pairs read from a Boilerplate YAML config file of the format:
+//
+// hookName:
+//   - command: <CMD>
+//     args:
+//       - <ARG>
+//
+//   - command: <CMD>
+//     args:
+//       - <ARG>
+//
+// This method takes looks up the given hookName in the map and unmarshals the data inside of it it into a list of
+// Hook structs
+func unmarshalHooksFromBoilerplateConfigYaml(fields map[string]interface{}, hookName string) ([]Hook, error) {
+	hookFields, err := unmarshalListOfFields(fields, hookName)
+	if err != nil || hookFields == nil {
+		return nil, err
+	}
+
+	hooks := []Hook{}
+
+	for _, hookField := range hookFields {
+		hook, err := unmarshalHookFromBoilerplateConfigYaml(hookField, hookName)
+		if err != nil {
+			return nil, err
+		}
+		hooks = append(hooks, *hook)
+	}
+
+	return hooks, nil
+}
+
+// Given key:value pairs read from a Boilerplate YAML config file of the format:
+//
+// command: <CMD>
+// args:
+//   - <ARG>
+//
+// This method unmarshals the YAML data into a Hook struct
+func unmarshalHookFromBoilerplateConfigYaml(fields map[string]interface{}, hookName string) (*Hook, error) {
+	command, err := unmarshalStringField(fields, "command", true, hookName)
+	if err != nil {
+		return nil, err
+	}
+
+	args, err := unmarshalListOfStrings(fields, "args")
+	if err != nil {
+		return nil, err
+	}
+
+	return &Hook{Command: *command, Args: args}, nil
+}


### PR DESCRIPTION
This PR adds the idea of `hooks` to boilerplate. A hook is an arbitrary shell command for Boilerplate to execute at specific times. Currently, two types of hooks are supported:

* The `before` hook allows you to run scripts before Boilerplate has started rendering.
* The `after` hook allows you to run scripts after Boilerplate has finished rendering.

Other hooks may be added in the future.

The motivating use cases for this are:

1. Create the initial IAM permissions in usage-patterns before generating a full stack for a new client.
1. Run `terragrunt spin-up` automatically after the full stack has been generated.