### PR TITLE
Add support for specifying env vars in shell helper and hooks

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,10 +228,14 @@ hooks:
     - command: <CMD>
       args:
         - <ARG>
+      env:
+        <KEY>: <VALUE>
   after:              
     - command: <CMD>
       args:
         - <ARG>
+      env:
+        <KEY>: <VALUE>
 ```
 
 Here's an example:
@@ -371,7 +375,8 @@ Note the following:
 
 * The `before` hook allows you to run scripts before Boilerplate has started rendering.
 * The `after` hook allows you to run scripts after Boilerplate has finished rendering.
-* Each hook consists of a `command` to execute (required) plus a list of `args` to pass to that command (optional).
+* Each hook consists of a `command` to execute (required), a list of `args` to pass to that command (optional), and
+  a map of environment variables in `env` to set for the command (optional).
   Example:
    
     ```yaml
@@ -380,8 +385,10 @@ Note the following:
         args:
           - Hello
           - World
+        env:
+          FOO: BAR
     ```
-* You can use Go templating syntax in both `command` and `args`. For example, you can pass Boilerplate variables to 
+* You can use Go templating syntax in `command`, `args`, and `env`. For example, you can pass Boilerplate variables to 
   your scripts as follows:
     
     ```yaml
@@ -453,9 +460,11 @@ including conditionals, loops, and functions. Boilerplate also includes several 
   way to do a for-loop over a range of numbers.
 * `keys MAP`: Return a slice that contains all the keys in the given MAP. Use the built-in Go template helper `.index`
   to look up these keys in the map.
-* `shell CMD`: Execute the given shell command and render whatever that command prints to stdout. The working directory
-  for the command will be set to the directory of the template being rendered, so you can use paths relative to the
-  file from which you are calling the `shell` helper. For another way to execute commands, see [hooks](#hooks).
+* `shell CMD ARGS...`: Execute the given shell command, passing it the given args, and render whatever that command 
+  prints to stdout. The working directory for the command will be set to the directory of the template being rendered, 
+  so you can use paths relative to the file from which you are calling the `shell` helper. Any argument you pass of the
+  form `ENV:KEY=VALUE` will be set as an environment variable for the command rather than an argument. For another way 
+  to execute commands, see [hooks](#hooks).
 * `templateFolder`: Return the value of the `--template-folder` command-line option. Useful for building relative paths.
 * `outputFolder`: Return the value of the `--output-folder` command-line option. Useful for building relative paths.
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -580,6 +580,8 @@ const CONFIG_ONE_AFTER_HOOK_WITH_ARGS =
        args:
          - bar
          - baz
+       env:
+         foo: bar
 `
 
 func TestParseBoilerplateConfigOneAfterHookWithArgs(t *testing.T) {
@@ -591,7 +593,7 @@ func TestParseBoilerplateConfigOneAfterHookWithArgs(t *testing.T) {
 		Dependencies: []variables.Dependency{},
 		Hooks: variables.Hooks{
 			AfterHooks: []variables.Hook{
-				{Command: "foo", Args: []string{"bar", "baz"}},
+				{Command: "foo", Args: []string{"bar", "baz"}, Env: map[string]string{"foo": "bar"}},
 			},
 		},
 	}
@@ -607,6 +609,9 @@ const CONFIG_MULTIPLE_HOOKS =
      - command: echo
        args:
          - Hello World
+       env:
+         foo: bar
+         baz: blah
 
      - command: run-some-script.sh
        args:
@@ -627,7 +632,7 @@ func TestParseBoilerplateConfigMultipleHooks(t *testing.T) {
 		Dependencies: []variables.Dependency{},
 		Hooks: variables.Hooks{
 			BeforeHooks: []variables.Hook{
-				{Command: "echo", Args: []string{"Hello World"}},
+				{Command: "echo", Args: []string{"Hello World"}, Env: map[string]string{"foo": "bar", "baz": "blah"}},
 				{Command: "run-some-script.sh", Args: []string{"{{ .foo }}", "{{ .bar }}"}},
 			},
 			AfterHooks: []variables.Hook{

--- a/examples/shell/boilerplate.yml
+++ b/examples/shell/boilerplate.yml
@@ -10,8 +10,9 @@ hooks:
 
     - command: ./example-script-2.sh
       args:
-        - "{{ .Text }} - executed via a before hook"
         - "{{ outputFolder }}/before-hook-example.txt"
+      env:
+        TEXT: "{{ .Text }} - executed via a before hook"
 
   after:
     - command: echo
@@ -20,5 +21,6 @@ hooks:
 
     - command: ./example-script-2.sh
       args:
-        - "{{ .Text }} - executed via an after hook"
         - "{{ outputFolder }}/after-hook-example.txt"
+      env:
+        TEXT: "{{ .Text }} - executed via an after hook"

--- a/examples/shell/example-script-2.sh
+++ b/examples/shell/example-script-2.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # An example script that will be executed via the 'shell' command in a boilerplate template. This script simply writes
-# the first argument you pass to it into the path in the second argument.
+# the environment variable TEXT into the path in the first argument.
 
-echo "$1" > "$2"
+echo "$TEXT" > "$1"

--- a/templates/template_processor.go
+++ b/templates/template_processor.go
@@ -84,7 +84,22 @@ func processHook(hook variables.Hook, options *config.BoilerplateOptions, vars m
 		args = append(args, renderedArg)
 	}
 
-	return util.RunShellCommand(options.TemplateFolder, cmd, args...)
+	envVars := []string{}
+	for key, value := range hook.Env {
+		renderedKey, err := renderTemplate(config.BoilerplateConfigPath(options.TemplateFolder), key, vars, options)
+		if err != nil {
+			return err
+		}
+
+		renderedValue, err := renderTemplate(config.BoilerplateConfigPath(options.TemplateFolder), value, vars, options)
+		if err != nil {
+			return err
+		}
+
+		envVars = append(envVars, fmt.Sprintf("%s=%s", renderedKey, renderedValue))
+	}
+
+	return util.RunShellCommand(options.TemplateFolder, envVars, cmd, args...)
 }
 
 // Execute the boilerplate templates in the given list of dependencies

--- a/templates/template_processor_test.go
+++ b/templates/template_processor_test.go
@@ -115,6 +115,7 @@ func TestRenderTemplate(t *testing.T) {
 		{"Slice test: {{ slice 0 5 1 }}", map[string]interface{}{}, config.ExitWithError, "", "Slice test: [0 1 2 3 4]"},
 		{"Keys test: {{ keys .Map }}", map[string]interface{}{"Map": map[string]string{"key1": "value1", "key2": "value2", "key3": "value3"}}, config.ExitWithError, "", "Keys test: [key1 key2 key3]"},
 		{"Shell test: {{ shell \"echo\" .Text }}", map[string]interface{}{"Text": "Hello, World"}, config.ExitWithError, "", "Shell test: Hello, World\n"},
+		{"Shell env vars test: {{ shell \"printenv\" \"FOO\" \"ENV:FOO=bar\" }}", map[string]interface{}{}, config.ExitWithError, "", "Shell env vars test: bar\n"},
 		{"Template folder test: {{ templateFolder }}", map[string]interface{}{}, config.ExitWithError, "", "Template folder test: /templates"},
 		{"Output folder test: {{ outputFolder }}", map[string]interface{}{}, config.ExitWithError, "", "Output folder test: /output"},
 		{"Filter chain test: {{ .Foo | downcase | replaceAll \" \" \"\" }}", map[string]interface{}{"Foo": "foo BAR baz!"}, config.ExitWithError, "", "Filter chain test: foobarbaz!"},

--- a/test-fixtures/examples-expected-output/shell/example-script-2.sh
+++ b/test-fixtures/examples-expected-output/shell/example-script-2.sh
@@ -1,5 +1,5 @@
 #!/bin/bash
 # An example script that will be executed via the 'shell' command in a boilerplate template. This script simply writes
-# the first argument you pass to it into the path in the second argument.
+# the environment variable TEXT into the path in the first argument.
 
-echo "$1" > "$2"
+echo "$TEXT" > "$1"

--- a/util/shell.go
+++ b/util/shell.go
@@ -7,8 +7,8 @@ import (
 	"github.com/gruntwork-io/boilerplate/errors"
 )
 
-// Run the given shell command with the given arguments in the given working directory
-func RunShellCommandAndGetOutput(workingDir string, command string, args ... string) (string, error) {
+// Run the given shell command with the given environment variables and arguments in the given working directory
+func RunShellCommandAndGetOutput(workingDir string, envVars []string, command string, args ... string) (string, error) {
 	Logger.Printf("Running command: %s %s", command, strings.Join(args, " "))
 
 	cmd := exec.Command(command, args...)
@@ -16,6 +16,7 @@ func RunShellCommandAndGetOutput(workingDir string, command string, args ... str
 	cmd.Stdin = os.Stdin
 	cmd.Stderr = os.Stderr
 	cmd.Dir = workingDir
+	cmd.Env = append(os.Environ(), envVars...)
 
 	out, err := cmd.Output()
 	if err != nil {
@@ -24,8 +25,8 @@ func RunShellCommandAndGetOutput(workingDir string, command string, args ... str
 	return string(out), nil
 }
 
-// Run the given shell command with the given arguments in the given working directory
-func RunShellCommand(workingDir string, command string, args ... string) error {
+// Run the given shell command with the given environment variables and arguments in the given working directory
+func RunShellCommand(workingDir string, envVars []string, command string, args ... string) error {
 	Logger.Printf("Running command: %s %s", command, strings.Join(args, " "))
 
 	cmd := exec.Command(command, args...)
@@ -34,6 +35,7 @@ func RunShellCommand(workingDir string, command string, args ... string) error {
 	cmd.Stderr = os.Stderr
 	cmd.Stdout = os.Stdout
 	cmd.Dir = workingDir
+	cmd.Env = append(os.Environ(), envVars...)
 
 	return cmd.Run()
 }

--- a/variables/hooks.go
+++ b/variables/hooks.go
@@ -4,6 +4,7 @@ package variables
 type Hook struct {
 	Command string
 	Args    []string
+	Env     map[string]string
 }
 
 // All the scripts to execute as boilerplate hooks
@@ -19,11 +20,15 @@ type Hooks struct {
 //     - command: <CMD>
 //       args:
 //         - <ARG>
+//       env:
+//         <KEY>: <VALUE>
 //
 //   after:
 //     - command: <CMD>
 //       args:
 //         - <ARG>
+//       env:
+//         <KEY>: <VALUE>
 //
 // This method takes the data above and unmarshals it into a Hooks struct
 func UnmarshalHooksFromBoilerplateConfigYaml(fields map[string]interface{}) (Hooks, error) {
@@ -51,10 +56,14 @@ func UnmarshalHooksFromBoilerplateConfigYaml(fields map[string]interface{}) (Hoo
 //   - command: <CMD>
 //     args:
 //       - <ARG>
+//     env:
+//       <KEY>: <VALUE>
 //
 //   - command: <CMD>
 //     args:
 //       - <ARG>
+//     env:
+//       <KEY>: <VALUE>
 //
 // This method takes looks up the given hookName in the map and unmarshals the data inside of it it into a list of
 // Hook structs
@@ -82,6 +91,8 @@ func unmarshalHooksFromBoilerplateConfigYaml(fields map[string]interface{}, hook
 // command: <CMD>
 // args:
 //   - <ARG>
+// env:
+//   <KEY>: <VALUE>
 //
 // This method unmarshals the YAML data into a Hook struct
 func unmarshalHookFromBoilerplateConfigYaml(fields map[string]interface{}, hookName string) (*Hook, error) {
@@ -95,5 +106,10 @@ func unmarshalHookFromBoilerplateConfigYaml(fields map[string]interface{}, hookN
 		return nil, err
 	}
 
-	return &Hook{Command: *command, Args: args}, nil
+	env, err := unmarshalMapOfStrings(fields, "env")
+	if err != nil {
+		return nil, err
+	}
+
+	return &Hook{Command: *command, Args: args, Env: env}, nil
 }

--- a/variables/yaml_helpers.go
+++ b/variables/yaml_helpers.go
@@ -17,7 +17,7 @@ import (
 //   key2: value2
 //   key3: value3
 //
-// This method takes looks up the given fieldName in the map and unmarshals the data inside of it it into a map of the
+// This method looks up the given fieldName in the map and unmarshals the data inside of it it into a map of the
 // key:value pairs.
 func unmarshalMapOfFields(fields map[string]interface{}, fieldName string) (map[string]interface{}, error) {
 	fieldAsYaml, containsField := fields[fieldName]
@@ -37,6 +37,33 @@ func unmarshalMapOfFields(fields map[string]interface{}, fieldName string) (map[
 		} else {
 			return nil, errors.WithStackTrace(InvalidTypeForField{FieldName: fieldName, ExpectedType: "string", ActualType: reflect.TypeOf(key)})
 		}
+	}
+
+	return stringMap, nil
+}
+
+// Given a map of key:value pairs read from a Boilerplate YAML config file of the format:
+//
+// fieldName:
+//   key1: value1
+//   key2: value2
+//   key3: value3
+//
+// This method looks up the given fieldName in the map and unmarshals the data inside of it it into a map of the
+// key:value pairs, where both the keys and values are strings.
+func unmarshalMapOfStrings(fields map[string]interface{}, fieldName string) (map[string]string, error) {
+	rawMap, err := unmarshalMapOfFields(fields, fieldName)
+	if err != nil {
+		return nil, err
+	}
+	if len(rawMap) == 0 {
+		return nil, nil
+	}
+
+	stringMap := map[string]string{}
+
+	for key, value := range rawMap {
+		stringMap[key] = fmt.Sprintf("%v", value)
 	}
 
 	return stringMap, nil


### PR DESCRIPTION
This PR allows you to specify environment variables when using the shell helper and hooks. This will be useful in a number of ways, but the main use case right now is to be able to specify a custom `TERRAGRUNT_SOURCE` environment variable so that as we are generating a project, Terragrunt uses the local copy of infrastructure-modules rather than trying to download something from Git that has not yet been committed/published.