### PR TITLE
Add helper to read environment variables

### DIFF
--- a/_docs/README.md
+++ b/_docs/README.md
@@ -202,10 +202,14 @@ hooks:
     - command: <CMD>
       args:
         - <ARG>
+      env:
+        <KEY>: <VALUE>        
   after:              
     - command: <CMD>
       args:
         - <ARG>
+      env:
+        <KEY>: <VALUE>
 ```
 
 Here's an example:
@@ -314,8 +318,8 @@ Note the following:
 
 * The `before` hook allows you to run scripts before Boilerplate has started rendering.
 * The `after` hook allows you to run scripts after Boilerplate has finished rendering.
-* Each hook consists of a `command` to execute (required) plus a list of `args` to pass to that command (optional).
-  Example:
+* Each hook consists of a `command` to execute (required), a list of `args` to pass to that command (optional), and
+  a map of environment variables in `env` to set for the command (optional). Example:
    
     ```yaml
     before:
@@ -323,9 +327,11 @@ Note the following:
         args:
           - Hello
           - World
+        env:
+          FOO: BAR
     ```
-* You can use Go templating syntax in both `command` and `args`. For example, you can pass Boilerplate variables to 
-  your scripts as follows:
+* You can use Go templating syntax in both `command`, `args`, and `env`. For example, you can pass Boilerplate 
+  variables to your scripts as follows:
     
     ```yaml
     before:
@@ -396,12 +402,16 @@ including conditionals, loops, and functions. Boilerplate also includes several 
   way to do a for-loop over a range of numbers.
 * `keys MAP`: Return a slice that contains all the keys in the given MAP. Use the built-in Go template helper `.index`
   to look up these keys in the map.
-* `shell CMD`: Execute the given shell command and render whatever that command prints to stdout. The working directory
-  for the command will be set to the directory of the template being rendered, so you can use paths relative to the
-  file from which you are calling the `shell` helper. For another way to execute commands, see [hooks](#hooks).
+* `shell CMD ARGS...`: Execute the given shell command, passing it the given args, and render whatever that command 
+  prints to stdout. The working directory for the command will be set to the directory of the template being rendered, 
+  so you can use paths relative to the file from which you are calling the `shell` helper. Any argument you pass of the
+  form `ENV:KEY=VALUE` will be set as an environment variable for the command rather than an argument. For another way 
+  to execute commands, see [hooks](#hooks).
 * `templateFolder`: Return the value of the `--template-folder` command-line option. Useful for building relative paths.
 * `outputFolder`: Return the value of the `--output-folder` command-line option. Useful for building relative paths.
-
+* `env NAME DEFAULT`: Render the value of environment variable `NAME`. If that environment variable is empty or not 
+  defined, render `DEFAULT` instead.
+  
 ## Alternative project generators
 
 Before creating Boilerplate, we tried a number of other project generators, but none of them met all of our

--- a/templates/template_helpers.go
+++ b/templates/template_helpers.go
@@ -76,6 +76,7 @@ func CreateTemplateHelpers(templatePath string, options *config.BoilerplateOptio
 		"relPath": relPath,
 		"boilerplateConfigDeps": boilerplateConfigDeps(options),
 		"boilerplateConfigVars": boilerplateConfigVars(options),
+		"env": env,
 	}
 }
 
@@ -478,6 +479,16 @@ func relPath(basePath, targetPath string) (string, error) {
 	}
 
 	return relPath, nil
+}
+
+// Returns the value of the environment variable with the given name. If that variable is not set, return fallbackValue.
+func env(name string, fallbackValue string) string {
+	value := os.Getenv(name)
+	if value == "" {
+		return fallbackValue
+	} else {
+		return value
+	}
 }
 
 // Find the value of the given property of the given Dependency.

--- a/templates/template_processor_test.go
+++ b/templates/template_processor_test.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"github.com/gruntwork-io/boilerplate/config"
 	"github.com/gruntwork-io/boilerplate/variables"
+	"fmt"
 )
 
 func TestOutPath(t *testing.T) {
@@ -77,6 +78,10 @@ func TestRenderTemplate(t *testing.T) {
 	pwd, err := os.Getwd()
 	assert.Nil(t, err, "Couldn't get working directory")
 
+	// Read an environment variable that's probably present on all systems so we can check that the env helper
+	// returns the same value
+	userFromEnvVar := os.Getenv("USER")
+
 	testCases := []struct {
 		templateContents  string
 		variables   	  map[string]interface{}
@@ -115,7 +120,9 @@ func TestRenderTemplate(t *testing.T) {
 		{"Slice test: {{ slice 0 5 1 }}", map[string]interface{}{}, config.ExitWithError, "", "Slice test: [0 1 2 3 4]"},
 		{"Keys test: {{ keys .Map }}", map[string]interface{}{"Map": map[string]string{"key1": "value1", "key2": "value2", "key3": "value3"}}, config.ExitWithError, "", "Keys test: [key1 key2 key3]"},
 		{"Shell test: {{ shell \"echo\" .Text }}", map[string]interface{}{"Text": "Hello, World"}, config.ExitWithError, "", "Shell test: Hello, World\n"},
-		{"Shell env vars test: {{ shell \"printenv\" \"FOO\" \"ENV:FOO=bar\" }}", map[string]interface{}{}, config.ExitWithError, "", "Shell env vars test: bar\n"},
+		{"Shell set env vars test: {{ shell \"printenv\" \"FOO\" \"ENV:FOO=bar\" }}", map[string]interface{}{}, config.ExitWithError, "", "Shell set env vars test: bar\n"},
+		{"Shell read env vars test: {{ env \"USER\" \"should-not-get-fallback\" }}", map[string]interface{}{}, config.ExitWithError, "", fmt.Sprintf("Shell read env vars test: %s", userFromEnvVar)},
+		{"Shell read env vars test, fallback: {{ env \"not-a-valid-env-var\" \"should-get-fallback\" }}", map[string]interface{}{}, config.ExitWithError, "", "Shell read env vars test, fallback: should-get-fallback"},
 		{"Template folder test: {{ templateFolder }}", map[string]interface{}{}, config.ExitWithError, "", "Template folder test: /templates"},
 		{"Output folder test: {{ outputFolder }}", map[string]interface{}{}, config.ExitWithError, "", "Output folder test: /output"},
 		{"Filter chain test: {{ .Foo | downcase | replaceAll \" \" \"\" }}", map[string]interface{}{"Foo": "foo BAR baz!"}, config.ExitWithError, "", "Filter chain test: foobarbaz!"},


### PR DESCRIPTION
In a previous PR, I added a helper to *set* environment variables when using the `shell` helper or `hooks`. This PR adds a helper to *read* environment variables. The nice thing is that these helpers are composable: that is, you can use the helper to read env vars both with the `shell` helper and with `hooks`.