### PR TITLE
Fix reference lookup so it works with dependencies

### DIFF
--- a/examples/variables-recursive/boilerplate.yml
+++ b/examples/variables-recursive/boilerplate.yml
@@ -28,3 +28,8 @@ variables:
   - name: BarMap
     type: map
     reference: FooMap
+
+dependencies:
+  - name: variables
+    template-folder: ../variables
+    output-folder: .

--- a/examples/variables/boilerplate.yml
+++ b/examples/variables/boilerplate.yml
@@ -1,0 +1,5 @@
+variables:
+  - name: BazMap
+    type: map
+    reference: FooMap
+

--- a/examples/variables/example.txt
+++ b/examples/variables/example.txt
@@ -1,0 +1,1 @@
+BazMap = {{ range $index, $key := (.BazMap | keys) }}{{ if gt $index 0 }}, {{ end }}{{ $key }}: {{ index $.BazMap $key }}{{ end }}

--- a/test-fixtures/examples-expected-output/variables-recursive/example.txt
+++ b/test-fixtures/examples-expected-output/variables-recursive/example.txt
@@ -1,0 +1,1 @@
+BazMap = bar: 2, baz: 3, foo: 1

--- a/variables/variables.go
+++ b/variables/variables.go
@@ -161,7 +161,7 @@ func (variable defaultVariable) WithDefault(value interface{}) Variable {
 }
 
 func (variable defaultVariable) String() string {
-	return fmt.Sprintf("Variable {Name: '%s', Description: '%s', Type: '%v', Default: '%v', Options: '%v'}", variable.Name(), variable.Description(), variable.Type(), variable.Default(), variable.Options())
+	return fmt.Sprintf("Variable {Name: '%s', Description: '%s', Type: '%v', Default: '%v', Options: '%v', Reference: '%v'}", variable.Name(), variable.Description(), variable.Type(), variable.Default(), variable.Options(), variable.Reference())
 }
 
 func (variable defaultVariable) ExampleValue() string {


### PR DESCRIPTION
In #35, I added support for the `reference` keyword. Unfortunately, it had a bug where it didn’t work if a dependency tried to reference a variable defined in a parent. This PR should fix that issue.