### PR TITLE
For map variables, render the key in addition to the value

### DIFF
--- a/examples/variables-recursive/README.md
+++ b/examples/variables-recursive/README.md
@@ -9,3 +9,5 @@ FooList = {{ range $index, $element := .FooList }}{{ if gt $index 0 }}, {{ end }
 BarList = {{ range $index, $element := .BarList }}{{ if gt $index 0 }}, {{ end }}{{ $element }}{{ end }}
 FooMap = {{ range $index, $key := (.FooMap | keys) }}{{ if gt $index 0 }}, {{ end }}{{ $key }}: {{ index $.FooMap $key }}{{ end }}
 BarMap = {{ range $index, $key := (.BarMap | keys) }}{{ if gt $index 0 }}, {{ end }}{{ $key }}: {{ index $.BarMap $key }}{{ end }}
+ListWithTemplates = {{ range $index, $element := .ListWithTemplates }}{{ if gt $index 0 }}, {{ end }}{{ $element }}{{ end }}
+MapWithTemplates = {{ range $index, $key := (.MapWithTemplates | keys) }}{{ if gt $index 0 }}, {{ end }}{{ $key }}: {{ index $.MapWithTemplates $key }}{{ end }}

--- a/examples/variables-recursive/boilerplate.yml
+++ b/examples/variables-recursive/boilerplate.yml
@@ -29,6 +29,20 @@ variables:
     type: map
     reference: FooMap
 
+  - name: ListWithTemplates
+    type: list
+    default:
+      - "{{ .Foo }}"
+      - "{{ .Bar }}"
+      - "{{ .Baz }}"
+
+  - name: MapWithTemplates
+    type: map
+    default:
+      "{{ .Foo }}": "{{ .Foo }}"
+      "{{ .Bar }}": "{{ .Bar }}"
+      "{{ .Baz }}": "{{ .Baz }}"
+
 dependencies:
   - name: variables
     template-folder: ../variables

--- a/templates/template_processor.go
+++ b/templates/template_processor.go
@@ -104,11 +104,16 @@ func renderVariable(variable interface{}, variables map[string]interface{}, opti
 	case map[string]string:
 		values := map[string]string{}
 		for key, value := range variableType {
-			rendered, err := renderTemplateRecursively(options.TemplateFolder, value, variables, options)
+			renderedKey, err := renderTemplateRecursively(options.TemplateFolder, key, variables, options)
 			if err != nil {
 				return nil, err
 			}
-			values[key] = rendered
+
+			renderedValue, err := renderTemplateRecursively(options.TemplateFolder, value, variables, options)
+			if err != nil {
+				return nil, err
+			}
+			values[renderedKey] = renderedValue
 		}
 		return values, nil
 	default:

--- a/test-fixtures/examples-expected-output/variables-recursive/README.md
+++ b/test-fixtures/examples-expected-output/variables-recursive/README.md
@@ -9,3 +9,5 @@ FooList = foo, bar, baz
 BarList = foo, bar, baz
 FooMap = bar: 2, baz: 3, foo: 1
 BarMap = bar: 2, baz: 3, foo: 1
+ListWithTemplates = foo, foo-bar, foo-bar-baz
+MapWithTemplates = foo: foo, foo-bar: foo-bar, foo-bar-baz: foo-bar-baz


### PR DESCRIPTION
In #34, I added support for variables using Go templating syntax. I was properly rendering strings, lists, and maps, except in the case of maps, I was only rendering the Go templating syntax in map values, and had forgotten to do the same for map keys. This PR fixes that issue.