### PR TITLE
Add ability to skip dependencies

### DIFF
--- a/_docs/README.md
+++ b/_docs/README.md
@@ -191,6 +191,7 @@ dependencies:
   - name: <DEPENDENCY_NAME>
     template-folder: <FOLDER>
     output-folder: <FOLDER>
+    skip: <CONDITION>
     dont-inherit-variables: <BOOLEAN>
     variables:
       - name: <NAME>
@@ -243,6 +244,9 @@ executing the current one. Each dependency may contain the following keys:
   current template.
 * `output-folder` (Required): Create the output files and folders in this folder. This path is relative to the output
   folder of the current template.
+* `skip` (Optional): Skip this dependency if this condition, which can use Go templating syntax and 
+  boilerplate variables, evaluates to the string `true`. This is useful to conditionally enable or disable 
+  dependencies.
 * `dont-inherit-variables` (Optional): By default, any variables already set as part of the current `boilerplate.yml`
   template will be reused in the dependency, so that the user is not prompted multiple times for the same variable. If
   you set this option to `false`, then the variables from the parent template will not be reused.
@@ -344,6 +348,25 @@ Note the following:
   to provide a value for a variable in a dependency.
 * Interpolation: You may use interpolation in the `template-folder` and `output-folder` parameters of your 
   dependencies. This allows you to use specify the paths to your template and output folders dynamically.
+* Conditional dependencies: You can enable or disable a dependency using the `skip` parameter, which supports Go
+  templating syntax and boilerplate variables. If the `skip` parameter evaluates to the string `true`, the 
+  dependency will be skipped; otherwise, it will be rendered. Example:
+  
+    ```yaml
+    variables:
+      - name: Foo
+        type: bool
+      
+      - name: Bar
+        type: bool
+    
+    dependencies:
+      - name: conditional-dependency-example
+        template-folder: ../foo
+        output-folder: foo
+        # Skip this dependency if both .Foo and .Bar are set to true
+        skip: "{{ and .Foo .Bar }}"
+    ```
 
 #### Hooks
 

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -370,6 +370,7 @@ const CONFIG_MULTIPLE_DEPENDENCIES =
   - name: dep3
     template-folder: /template/folder3
     output-folder: /output/folder3
+    skip: "{{ and .Foo .Bar }}"
 `
 
 func TestParseBoilerplateConfigMultipleDependencies(t *testing.T) {
@@ -401,6 +402,7 @@ func TestParseBoilerplateConfigMultipleDependencies(t *testing.T) {
 				OutputFolder: "/output/folder3",
 				DontInheritVariables: false,
 				Variables: []variables.Variable{},
+				Skip: "{{ and .Foo .Bar }}",
 			},
 		},
 		Hooks: variables.Hooks{},

--- a/examples/dependencies-dynamic/boilerplate.yml
+++ b/examples/dependencies-dynamic/boilerplate.yml
@@ -22,10 +22,26 @@ variables:
   - name: WebsiteOutputFolder
     description: The path to the website output folder. This is used to check that interpolations work in the output-folder parameter of dependencies.
 
+  - name: SkipAllDependencies
+    description: Set to true to skip all dependencies
+    type: bool
+    default: false
+
+  - name: SkipFirstWebsiteDependency
+    description: Set to true to skip the first website dependency
+    type: bool
+    default: false
+
+  - name: SkipSecondWebsiteDependency
+    description: Set to true to skip the second website dependency
+    type: bool
+    default: true
+
 dependencies:
     - name: docs
       template-folder: ../docs
       output-folder: ./docs
+      skip: "{{ .SkipAllDependencies }}"
       variables:
         - name: Title
           description: Enter the title of the docs page
@@ -33,6 +49,16 @@ dependencies:
     - name: website
       template-folder: "{{ .WebsiteTemplateFolder }}"
       output-folder: "{{ .WebsiteOutputFolder }}"
+      skip: "{{ or .SkipAllDependencies .SkipFirstWebsiteDependency }}"
       variables:
         - name: Title
           description: Enter the title of the website
+
+    - name: skip-website
+      template-folder: "{{ .WebsiteTemplateFolder }}"
+      output-folder: "{{ .WebsiteOutputFolder }}"
+      skip: "{{ or .SkipAllDependencies .SkipSecondWebsiteDependency }}"
+      variables:
+        - name: Title
+          description: Enter the title of the website
+          default: This website dependency should be skipped

--- a/variables/dependencies.go
+++ b/variables/dependencies.go
@@ -9,11 +9,12 @@ import (
 
 // A single boilerplate template that this boilerplate.yml depends on being executed first
 type Dependency struct {
-	Name                  string
-	TemplateFolder        string
-	OutputFolder          string
-	DontInheritVariables  bool
-	Variables             []Variable
+	Name                 string
+	TemplateFolder       string
+	OutputFolder         string
+	Skip                 string
+	DontInheritVariables bool
+	Variables            []Variable
 }
 
 // Get all the variables in this dependency, namespacing each variable with the name of this dependency
@@ -102,6 +103,15 @@ func UnmarshalDependencyFromBoilerplateConfigYaml(fields map[string]interface{})
 		return nil, err
 	}
 
+	skipPtr, err := unmarshalStringField(fields, "skip", false, *name)
+	if err != nil {
+		return nil, err
+	}
+	var skip string
+	if skipPtr != nil {
+		skip = *skipPtr
+	}
+
 	dontInheritVariables, err := unmarshalBooleanField(fields, "dont-inherit-variables", false, *name)
 	if err != nil {
 		return nil, err
@@ -116,6 +126,7 @@ func UnmarshalDependencyFromBoilerplateConfigYaml(fields map[string]interface{})
 		Name: *name,
 		TemplateFolder: *templateFolder,
 		OutputFolder: *outputFolder,
+		Skip: skip,
 		DontInheritVariables: dontInheritVariables,
 		Variables: variables,
 	}, nil


### PR DESCRIPTION
This PR adds a new `skip` attribute to dependencies. If this attribute, which supports Go templating syntax, evaluates to `true`, the dependency will be skipped. This is useful for conditionally including/excluding dependencies.