### PR TITLE
Allow multiple colons in map values

### DIFF
--- a/variables/variables.go
+++ b/variables/variables.go
@@ -290,12 +290,12 @@ func parseStringAsMap(str string) (map[string]string, error) {
 
 	for _, keyAndValue := range keysAndValues {
 		parts := strings.Split(keyAndValue, ":")
-		if len(parts) != 2 {
+		if len(parts) < 2 {
 			return nil, errors.WithStackTrace(ParseError{ExpectedType: "map", ExpectedFormat: "<key>:<value> for each item in the map", ActualFormat: str})
 		}
 
-		key := parts[0]
-		value := parts[1]
+		key := strings.Join(parts[:(len(parts) - 1)], ":")
+		value := parts[len(parts) - 1]
 
 		result[key] = value
 	}

--- a/variables/variables_test.go
+++ b/variables/variables_test.go
@@ -39,6 +39,7 @@ func TestParseStringAsMap(t *testing.T) {
 		{"empty-map", "map[]", map[string]string{}},
 		{"one-item", "map[a:b]", map[string]string{"a": "b"}},
 		{"three-items", "map[a:b c:d e:f]", map[string]string{"a": "b", "c": "d", "e": "f"}},
+		{"multiple-colons", "map[a:b:c:d:e]", map[string]string{"a:b:c:d": "e"}},
 	}
 
 	for _, testCase := range testCases {


### PR DESCRIPTION
Small PR to allow the parsing of maps to handle multiple colons in the key.