### PR TITLE
Fix deploy step

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,7 @@ jobs:
             # Install the gruntwork-module-circleci-helpers and use it to configure the build environment and run tests.
             curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version "${GRUNTWORK_INSTALLER_VERSION}"
             gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "${MODULE_CI_VERSION}"
+            gruntwork-install --module-name "git-helpers" --repo "https://github.com/gruntwork-io/module-ci" --tag "${MODULE_CI_VERSION}"
             configure-environment-for-gruntwork-module \
               --circle-ci-2-machine-executor \
               --terraform-version ${TERRAFORM_VERSION} \


### PR DESCRIPTION
The deploy step was failing due to the changes I made to circleci. We no longer have the binaries available at deploy time since the workspace sharing was removed. I fixed this by flipping the steps so that the binaries are built before using them for the docs.