### PR TITLE
Include function docs need to be in the boilerplate version

### DIFF
--- a/_docs/README.md
+++ b/_docs/README.md
@@ -449,6 +449,12 @@ Boilerplate also includes several custom helpers that you can access that enhanc
    return str2;
    // boilerplate-snippet: foo
    ```
+* `include <PATH> <VARIABLES>`: Returns the contents of the file at `PATH` after rendering it through the templating
+  engine with the provided variables, as a string (unlike `snippet`, which returns the contents of the file verbatim).
+  Use `.` to pass the current variables to the included template. E.g:
+  ```
+  {{ include "../source-template.snippet" . }}
+  ```
 * `replaceOne OLD NEW`: Replace the first occurrence of `OLD` with `NEW`. This is a literal replace, not regex.
 * `replaceAll OLD NEW`: Replace all occurrences of `OLD` with `NEW`. This is a literal replace, not regex.
 * `roundInt FLOAT`: Round `FLOAT` to the nearest integer. E.g. 1.5 becomes 2.


### PR DESCRIPTION
This adds the docs for the `include` function into the boilerplate README.md, instead of the root repo README.md where it was overwritten by CD when we released a new version.

Also address https://github.com/gruntwork-io/boilerplate/pull/55#discussion_r359689224