### PR TITLE
Fix issue with unmarshaling yaml maps

### DIFF
--- a/config/config.go
+++ b/config/config.go
@@ -91,7 +91,15 @@ func ParseBoilerplateConfig(configContents []byte) (*BoilerplateConfig, error) {
 		return nil, errors.WithStackTrace(err)
 	}
 
-	boilerplateConfig = variables.Convert(boilerplateConfig).(*BoilerplateConfig)
+	converted, err := variables.ConvertYAMLToStringMap(boilerplateConfig)
+	if err != nil {
+		return boilerplateConfig, err
+	}
+
+	boilerplateConfig, ok := converted.(*BoilerplateConfig)
+	if !ok {
+		return nil, variables.YAMLConversionErr{Key: converted}
+	}
 
 	return boilerplateConfig, nil
 }

--- a/variables/variables.go
+++ b/variables/variables.go
@@ -234,7 +234,11 @@ func ConvertType(value interface{}, variable Variable) (interface{}, error) {
 		}
 	case Map:
 		if reflect.TypeOf(value).Kind() == reflect.Map {
-			return Convert(value), nil
+			value, err := ConvertYAMLToStringMap(value)
+			if err != nil {
+				return nil, err
+			}
+			return value, nil
 		}
 		if isString {
 			return parseStringAsMap(asString)

--- a/variables/yaml_helpers_test.go
+++ b/variables/yaml_helpers_test.go
@@ -110,10 +110,20 @@ func TestConvert(t *testing.T) {
 			},
 			expectedType: []interface{}{},
 		},
+		{
+			input: map[string]interface{}{
+				"key3": 42,
+				"key1": map[string]interface{}{
+					"key2": "value2",
+				},
+			},
+			expectedType: map[string]interface{}{},
+		},
 	}
 
 	for _, testCase := range testCases {
-		actual := Convert(testCase.input)
+		actual, err := ConvertYAMLToStringMap(testCase.input)
+		assert.NoError(t, err)
 		assert.IsType(t, testCase.expectedType, actual)
 	}
 }


### PR DESCRIPTION
This works around [an issue in the `yaml` package](https://github.com/go-yaml/yaml/issues/139) that causes YAML maps to be unable to be marshalled to JSON.

What was happening was that unmarshaling a map variable like this:

```
SomeMap:
  SomeKey: SomeVal
```

would result in a variable of type `map[interface{}]interface{}` rather than `map[string]interface{}`. The former cannot be marshaled to JSON correctly since the JSON package (and the JSON spec) require that keys are strings. Hence you could not marshal the map to JSON in a boilerplate template like this:

```
{{ .SomeMap | toPrettyJson }}
```

where [`toPrettyJson` is a function in sprig](https://masterminds.github.io/sprig/defaults.html). It would instead just render an empty string.

- [x] Needs a unit test