### PR TITLE
Support marshaling boilerplate config to yaml

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -17,6 +17,7 @@ require (
 	github.com/mattn/go-zglob v0.0.2-0.20190814121620-e3c945676326
 	github.com/mitchellh/copystructure v1.0.0 // indirect
 	github.com/stretchr/testify v1.6.1
+	github.com/stuart-warren/yamlfmt v0.1.0
 	github.com/urfave/cli v1.22.4
 	golang.org/x/crypto v0.0.0-20200820211705-5c72a883971a // indirect
 	gopkg.in/yaml.v2 v2.3.0

--- a/go.sum
+++ b/go.sum
@@ -342,6 +342,7 @@ github.com/russross/blackfriday/v2 v2.0.1 h1:lPqVAte+HuHNfhJ/0LC98ESWRz8afy9tM/0
 github.com/russross/blackfriday/v2 v2.0.1/go.mod h1:+Rmxgy9KzJVeS9/2gXHxylqXiyQDYRxCVz55jmeOWTM=
 github.com/satori/go.uuid v1.2.0/go.mod h1:dA0hQrYB0VpLJoorglMZABFdXlWrHn1NEOzdhQKdks0=
 github.com/sclevine/spec v1.2.0/go.mod h1:W4J29eT/Kzv7/b9IWLB055Z+qvVC9vt0Arko24q7p+U=
+github.com/sergi/go-diff v1.1.0 h1:we8PVUC3FE2uYfodKH/nBHMSetSfHDR6scGdBi+erh0=
 github.com/sergi/go-diff v1.1.0/go.mod h1:STckp+ISIX8hZLjrqAeVduY0gWCT9IjLuqbuNXdaHfM=
 github.com/shurcooL/sanitized_anchor_name v1.0.0 h1:PdmoCO6wvbs+7yrJyMORt4/BmY5IYyJwS/kOiWx8mHo=
 github.com/shurcooL/sanitized_anchor_name v1.0.0/go.mod h1:1NzhyTcUVG4SuEtjjoZeVRXNmyL/1OwPU0+IJeTBvfc=
@@ -370,6 +371,8 @@ github.com/stretchr/testify v1.3.0/go.mod h1:M5WIy9Dh21IEIfnGCwXGc5bZfKNJtfHm1UV
 github.com/stretchr/testify v1.4.0/go.mod h1:j7eGeouHqKxXV5pUuKE4zz7dFj8WfuZ+81PSLYec5m4=
 github.com/stretchr/testify v1.6.1 h1:hDPOHmpOpP40lSULcqw7IrRb/u7w6RpDC9399XyoNd0=
 github.com/stretchr/testify v1.6.1/go.mod h1:6Fq8oRcR53rry900zMqJjRRixrwX3KX962/h/Wwjteg=
+github.com/stuart-warren/yamlfmt v0.1.0 h1:KLjF+abSLmgyQImog3ZAlHqpmRU1eslkbAtYNhOD3PY=
+github.com/stuart-warren/yamlfmt v0.1.0/go.mod h1:X5TuPH+hf4O0U1KBvNqygvHbvAnoi9Wyl9BbtPv8SZk=
 github.com/tmc/grpc-websocket-proxy v0.0.0-20170815181823-89b8d40f7ca8/go.mod h1:ncp9v5uamzpCO7NfCPTXjqaC+bZgJeR0sMTm6dMHP7U=
 github.com/ugorji/go/codec v0.0.0-20181204163529-d75b2dcb6bc8/go.mod h1:VFNgLljTbGfSG7qAOspJ7OScBnGdDN/yBr0sguwnwf0=
 github.com/ulikunitz/xz v0.5.5 h1:pFrO0lVpTBXLpYw+pnLj6TbvHuyjXMfjGeCwSqCVwok=
@@ -575,6 +578,7 @@ gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405 h1:yhCVgyC4o1eVCa2tZl7eS0r+
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127 h1:qIbj1fsPNlZgppZ+VLlY7N33q108Sa+fhmuc+sWQYwY=
 gopkg.in/check.v1 v1.0.0-20180628173108-788fd7840127/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
+gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15 h1:YR8cESwS4TdDjEe65xsg0ogRM/Nc3DYOhEAlW+xobZo=
 gopkg.in/check.v1 v1.0.0-20190902080502-41f04d3bba15/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=
 gopkg.in/cheggaaa/pb.v1 v1.0.25/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
 gopkg.in/cheggaaa/pb.v1 v1.0.27/go.mod h1:V/YB90LKu/1FcN3WVnfiiE5oMCibMjukxqG/qStrOgw=
@@ -594,6 +598,7 @@ gopkg.in/yaml.v2 v2.2.4/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.2.8/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
 gopkg.in/yaml.v2 v2.3.0 h1:clyUAQHOM3G0M3f5vQj7LuJrETvjVot3Z5el9nffUtU=
 gopkg.in/yaml.v2 v2.3.0/go.mod h1:hI93XBmqTisBFMUTm0b8Fm+jr3Dg1NNxqwp+5A1VGuI=
+gopkg.in/yaml.v3 v3.0.0-20190709130402-674ba3eaed22/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c h1:dUUwHk2QECo/6vqA44rthZ8ie2QXMNeKRTHCNY2nXvo=
 gopkg.in/yaml.v3 v3.0.0-20200313102051-9f266ea9e77c/go.mod h1:K4uyk7z7BCEPqu6E+C64Yfv1cQ7kz7rIZviUmN+EgEM=
 gotest.tools v2.2.0+incompatible/go.mod h1:DsYFclhRJ6vuDpmuTbkuFWG+y2sxOXAzmJt81HFBacw=

--- a/test-fixtures/marshal-yaml-test/shell/expected.yml
+++ b/test-fixtures/marshal-yaml-test/shell/expected.yml
@@ -1,0 +1,29 @@
+variables:
+- description: Enter the text to display
+  name: Text
+  type: string
+hooks:
+  after:
+  - command: echo
+    args:
+    - Running after hooks
+  - command: ./example-script-2.sh
+    args:
+    - '{{ outputFolder }}/after-hook-example.txt'
+    env:
+      TEXT: '{{ .Text }} - executed via an after hook'
+  before:
+  - command: echo
+    args:
+    - Running before hooks
+  - command: ./example-script-2.sh
+    args:
+    - '{{ outputFolder }}/before-hook-example.txt'
+    env:
+      TEXT: '{{ .Text }} - executed via a before hook'
+  - command: ./example-script-2.sh
+    args:
+    - '{{ outputFolder }}/before-hook-should-be-skipped.txt'
+    env:
+      TEXT: this hook should be skipped
+    skip: "true"

--- a/test-fixtures/marshal-yaml-test/variables-recursive/expected.yml
+++ b/test-fixtures/marshal-yaml-test/variables-recursive/expected.yml
@@ -1,0 +1,100 @@
+dependencies:
+- name: variables
+  output-folder: .
+  template-url: ../variables
+variables:
+- name: Foo
+  type: string
+- default: '{{ .Foo }}-bar'
+  name: Bar
+  type: string
+- default: '{{ .Bar }}-baz'
+  name: Baz
+  type: string
+- default:
+  - foo
+  - bar
+  - baz
+  name: FooList
+  type: list
+- name: BarList
+  reference: FooList
+  type: list
+- default:
+    bar: 2
+    baz: 3
+    foo: 1
+  name: FooMap
+  type: map
+- name: BarMap
+  reference: FooMap
+  type: map
+- default:
+  - '{{ .Foo }}'
+  - '{{ .Bar }}'
+  - '{{ .Baz }}'
+  name: ListWithTemplates
+  type: list
+- default:
+    '{{ .Bar }}': '{{ .Bar }}'
+    '{{ .Baz }}': '{{ .Baz }}'
+    '{{ .Foo }}': '{{ .Foo }}'
+  name: MapWithTemplates
+  type: map
+- default:
+  - name: foo
+    value: foo
+  - name: bar
+    value: bar
+  name: ListWithNestedMap
+  type: list
+- default:
+    bar:
+    - 4
+    - 5
+    - 6
+    foo:
+    - 1
+    - 2
+    - 3
+  name: MapWithNestedList
+  type: map
+- default: 42
+  name: IntValue
+  type: int
+- default: '{{ .IntValue }}'
+  name: IntValueInterpolation
+  type: int
+- default: 3.14
+  name: FloatValue
+  type: float
+- default: '{{ .FloatValue }}'
+  name: FloatValueInterpolation
+  type: float
+- default: true
+  name: BoolValue
+  type: bool
+- default: '{{ .BoolValue }}'
+  name: BoolValueInterpolationSimple
+  type: bool
+- default: '{{ eq .IntValue 42 }}'
+  name: BoolValueInterpolationSimpleComplex
+  type: bool
+- default:
+  - 1
+  - 2
+  - 3
+  name: ListValue
+  type: list
+- default: '{{ .ListValue }}'
+  name: ListValueInterpolation
+  type: list
+- default:
+    bar: 2
+    baz: 3
+    foo: 1
+  name: MapValue
+  type: map
+- default: '{{ .MapValue }}'
+  name: MapValueInterpolation
+  type: map

--- a/util/marshal.go
+++ b/util/marshal.go
@@ -1,0 +1,47 @@
+package util
+
+import (
+	"fmt"
+
+	"github.com/gruntwork-io/boilerplate/errors"
+	"gopkg.in/yaml.v2"
+)
+
+// MarshalListOfObjectsToYAML will marshal the list of objects to yaml by calling MarshalYAML on every item in the list
+// and return the results as a list. This is useful when building a custom YAML marshaler.
+func MarshalListOfObjectsToYAML(inputList []interface{}) ([]interface{}, error) {
+	output := []interface{}{}
+	for _, item := range inputList {
+		itemAsMarshaler, hasType := item.(yaml.Marshaler)
+		if hasType == false {
+			return nil, errors.WithStackTrace(UnmarshalableObjectErr{item})
+		}
+		yaml, err := itemAsMarshaler.MarshalYAML()
+		if err != nil {
+			return nil, errors.WithStackTrace(ObjectMarshalingErr{item, err})
+		}
+		output = append(output, yaml)
+	}
+	return output, nil
+}
+
+// Custom errors
+
+// ObjectMarshalingErr is returned when there was an error marshaling the given object to yaml.
+type ObjectMarshalingErr struct {
+	object        interface{}
+	underlyingErr error
+}
+
+func (err ObjectMarshalingErr) Error() string {
+	return fmt.Sprintf("Error marshaling %v to YAML: %s", err.object, err.underlyingErr)
+}
+
+// UnmarshalableObjectErr is returned when the given object does not implement Marshaler interface.
+type UnmarshalableObjectErr struct {
+	object interface{}
+}
+
+func (err UnmarshalableObjectErr) Error() string {
+	return fmt.Sprintf("Can not marshal %v to YAML", err.object)
+}

--- a/variables/engines.go
+++ b/variables/engines.go
@@ -14,8 +14,8 @@ import (
 // - Jsonnet
 //
 type Engine struct {
-	Path           string
-	TemplateEngine TemplateEngineType
+	Path           string             `yaml:"path"`
+	TemplateEngine TemplateEngineType `yaml:"template_engine"`
 }
 
 type TemplateEngineType string

--- a/variables/hooks.go
+++ b/variables/hooks.go
@@ -1,5 +1,9 @@
 package variables
 
+import (
+	"github.com/gruntwork-io/boilerplate/util"
+)
+
 // A single hook, which is a command that is executed by boilerplate
 type Hook struct {
 	Command string
@@ -12,6 +16,54 @@ type Hook struct {
 type Hooks struct {
 	BeforeHooks []Hook
 	AfterHooks  []Hook
+}
+
+// Implement the go-yaml marshaler interface so that the config can be marshaled into yaml. We use a custom marshaler
+// instead of defining the fields as tags so that we skip the attributes that are empty.
+func (hook Hook) MarshalYAML() (interface{}, error) {
+	hookYml := map[string]interface{}{}
+	if hook.Command != "" {
+		hookYml["command"] = hook.Command
+	}
+	if hook.Skip != "" {
+		hookYml["skip"] = hook.Skip
+	}
+	if len(hook.Args) > 0 {
+		hookYml["args"] = hook.Args
+	}
+	if len(hook.Env) > 0 {
+		hookYml["env"] = hook.Env
+	}
+	return hookYml, nil
+}
+func (hooks Hooks) MarshalYAML() (interface{}, error) {
+	hooksYml := map[string]interface{}{}
+	// Due to go type system, we can only pass through []interface{}, even though []Hook is technically
+	// polymorphic to that type. So we reconstruct the list using the right type before passing it in to the marshal
+	// function.
+	if len(hooks.BeforeHooks) > 0 {
+		interfaceList := []interface{}{}
+		for _, hook := range hooks.BeforeHooks {
+			interfaceList = append(interfaceList, hook)
+		}
+		beforeYml, err := util.MarshalListOfObjectsToYAML(interfaceList)
+		if err != nil {
+			return nil, err
+		}
+		hooksYml["before"] = beforeYml
+	}
+	if len(hooks.AfterHooks) > 0 {
+		interfaceList := []interface{}{}
+		for _, hook := range hooks.AfterHooks {
+			interfaceList = append(interfaceList, hook)
+		}
+		afterYml, err := util.MarshalListOfObjectsToYAML(interfaceList)
+		if err != nil {
+			return nil, err
+		}
+		hooksYml["after"] = afterYml
+	}
+	return hooksYml, nil
 }
 
 // Given a map of key:value pairs read from a Boilerplate YAML config file of the format:

--- a/variables/skip_files.go
+++ b/variables/skip_files.go
@@ -6,6 +6,19 @@ type SkipFile struct {
 	If   string
 }
 
+// Implement the go-yaml marshaler interface so that the config can be marshaled into yaml. We use a custom marshaler
+// instead of defining the fields as tags so that we skip the attributes that are empty.
+func (skipFile SkipFile) MarshalYAML() (interface{}, error) {
+	skipFileYml := map[string]interface{}{}
+	if skipFile.Path != "" {
+		skipFileYml["path"] = skipFile.Path
+	}
+	if skipFile.If != "" {
+		skipFileYml["if"] = skipFile.If
+	}
+	return skipFileYml, nil
+}
+
 // Given a list of key:value pairs read from a Boilerplate YAML config file of the format:
 //
 // skip_files:

--- a/variables/variables.go
+++ b/variables/variables.go
@@ -49,6 +49,9 @@ type Variable interface {
 
 	// Show an example value that would be valid for this variable
 	ExampleValue() string
+
+	// A custom marshaling function to translate back to YAML, as expected by go-yaml.
+	MarshalYAML() (interface{}, error)
 }
 
 // A private implementation of the Variable interface that forces all users to use our public constructors
@@ -189,6 +192,31 @@ func (variable defaultVariable) ExampleValue() string {
 	default:
 		return ""
 	}
+}
+
+// Define a custom marshaler for YAML so that variables (and thus any struct using it) can be marshaled into YAML.
+func (variable defaultVariable) MarshalYAML() (interface{}, error) {
+	varYml := map[string]interface{}{}
+	// We avoid a straight assignment to ensure that only fields that are actually set are rendered out.
+	if variable.Name() != "" {
+		varYml["name"] = variable.Name()
+	}
+	if variable.Description() != "" {
+		varYml["description"] = variable.Description()
+	}
+	if variable.Type() != "" {
+		varYml["type"] = variable.Type()
+	}
+	if variable.Default() != nil {
+		varYml["default"] = variable.Default()
+	}
+	if variable.Reference() != "" {
+		varYml["reference"] = variable.Reference()
+	}
+	if len(variable.Options()) > 0 {
+		varYml["options"] = variable.Options()
+	}
+	return varYml, nil
 }
 
 // Check that the given value matches the type we're expecting in the given variable and return an error if it doesn't


### PR DESCRIPTION
This adds marshaling functions to all the boilerplate config structs.

Use case: This is useful to machine generate boilerplate configuration files, which is something we plan on doing in the `refarch-deployer` CLI.