### PR TITLE
Fix template rendering for skip files and engines

### DIFF
--- a/examples/skip-not-path/boilerplate.yml
+++ b/examples/skip-not-path/boilerplate.yml
@@ -1,2 +1,6 @@
+variables:
+  - name: SkipNotPath
+    default: "docs"
+
 skip_files:
-  - not_path: docs/**
+  - not_path: "{{ .SkipNotPath }}/**"

--- a/templates/engines_processor.go
+++ b/templates/engines_processor.go
@@ -25,7 +25,7 @@ func processEngines(
 ) ([]ProcessedEngine, error) {
 	output := []ProcessedEngine{}
 	for _, engine := range engines {
-		matchedPaths, err := renderGlobPath(opts, engine.Path)
+		matchedPaths, err := renderGlobPath(opts, engine.Path, variables)
 		if err != nil {
 			return nil, err
 		}


### PR DESCRIPTION
The `path` and `not_path` attributes for `skip_files` and `engines` was not being rendered through boilerplate templating, when we want it to support that.

As a bonus, this adds more logging on `glob` failures so it is easier to understand what is going on. Otherwise, you get an unhelpful error message that simply states `file does not exist`.