### PR TITLE
Fix the usability of templateFolder and outputFolder

### DIFF
--- a/render/template_helpers.go
+++ b/render/template_helpers.go
@@ -93,8 +93,8 @@ func CreateTemplateHelpers(templatePath string, opts *options.BoilerplateOptions
 
 		"templateIsDefined": wrapIsDefinedWithTemplate(tmpl),
 
-		"templateFolder":        func() string { return opts.TemplateFolder },
-		"outputFolder":          func() string { return opts.OutputFolder },
+		"templateFolder":        func() (string, error) { return filepath.Abs(opts.TemplateFolder) },
+		"outputFolder":          func() (string, error) { return filepath.Abs(opts.OutputFolder) },
 		"relPath":               relPath,
 		"boilerplateConfigDeps": boilerplateConfigDeps(opts),
 		"boilerplateConfigVars": boilerplateConfigVars(opts),


### PR DESCRIPTION
<!--
Have any questions? Check out the contributing docs at https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e,
or ask in this Pull Request and a Gruntwork core maintainer will be happy to help :)
Note: Remember to add '[WIP]' to the beginning of the title if this PR is still a work-in-progress. Remove it when it is ready for review!
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This updates the `templateFolder` and `outputFolder` helpers to return absolute paths instead of the raw, relative paths. Using relative paths breaks the intended usage of these functions, which is to create relative paths in templates. Specifically, these functions return garbage values when using relative path inputs to `--template-url` and `--output-folder`, as these get repeated in the boilerplate blueprints, leading to broken relative pathing.

Using absolute paths ensure that the relative paths constructed in the boilerplate templates always point to the intended locations.


## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [x] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [x] Update the docs.
- [x] Keep the changes backward compatible where possible.
- [x] Run the pre-commit checks successfully.
- [x] Run the relevant tests successfully.

## Note on backward compatibility

I intend to release this as backward incompatible release given that the output of `templateFolder` and `outputFolder` changes, which will break anything that renders it in, say, docs, but for most use cases of those helpers, this should be functionally equivalent. E.g., I don't expect these changes to break our Reference Architecture.

All this is to say that there will be an explanation, but no migration guide will be provided given the functional equivalence.