### PR TITLE
Bump CI version to create arm bins

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -60,13 +60,13 @@ jobs:
       - run:
           <<: *install_gruntwork_tooling
 
-      - run: go get github.com/mitchellh/gox
-
       - run:
           name: release assets
           command: |
+            go install github.com/mitchellh/gox@latest
+
             # If a new release is tagged in GitHub, build the binaries and upload them to GitHub.
-            build-go-binaries \
+            PATH="/home/circleci/go/bin:$PATH" build-go-binaries \
               --app-name boilerplate \
               --dest-path bin \
               --ld-flags "-X main.VERSION=$CIRCLE_TAG"


### PR DESCRIPTION
<!--
Have any questions? Check out the contributing docs at https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e,
or ask in this Pull Request and a Gruntwork core maintainer will be happy to help :)
Note: Remember to add '[WIP]' to the beginning of the title if this PR is still a work-in-progress. Remove it when it is ready for review!
-->

## Description

<!-- Write a brief description of the changes introduced by this PR -->
This bumps the `terraform-aws-ci` version so that we create `arm64` binaries.

This also updates the circleci job to use docker with a smaller instance class, since boilerplate testing doesn't need the machine executor nor a lot of resources.

<!-- Important: Did you make any backward incompatible changes? If yes, then you must write a migration guide! -->

## TODOs

Please ensure all of these TODOs are completed before asking for a review.

- [x] Ensure the branch is named correctly with the issue number. e.g: `feature/new-vpc-endpoints-955` or `bug/missing-count-param-434`.
- [x] Update the docs.
- [x] Keep the changes backward compatible where possible.
- [x] Run the pre-commit checks successfully.
- [x] Run the relevant tests successfully.
