### PR TITLE
Update LICENSE.txt

### DIFF
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -1,6 +1,6 @@
 Gruntwork License
 
-Copyright (c) 2020 Gruntwork, Inc.
+Copyright (c) 2016 Gruntwork, Inc.
 
 This code is the property of Gruntwork, Inc. In the Master Services Agreement signed by both Gruntwork and your
 company, Gruntwork grants you a limited license to use, modify, and create derivative works of this code. Please


### PR DESCRIPTION
Slack thread for context. https://gruntwork-io.slack.com/archives/C033RFANFJL/p1657716951993829?thread_ts=1657639685.886649&cid=C033RFANFJL

Unless we intended to update the date of license as starting from 2020, there's no harm in reflecting the original year of 2016.