### PR TITLE
Attempt to provide more helpful error message when git URL may be misspelled

### DIFF
--- a/integration-tests/error_message_test.go
+++ b/integration-tests/error_message_test.go
@@ -1,0 +1,35 @@
+package integration_tests
+
+import (
+	"io/ioutil"
+	"os"
+	"testing"
+
+	"github.com/gruntwork-io/boilerplate/cli"
+	"github.com/gruntwork-io/boilerplate/errors"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMisspelledTemplateURLErrorMessage(t *testing.T) {
+	t.Parallel()
+
+	templateFolder := "../test-fixtures/regression-test/misspelled-git"
+
+	outputFolder, err := ioutil.TempDir("", "boilerplate-test-output")
+	require.NoError(t, err)
+	defer os.RemoveAll(outputFolder)
+
+	app := cli.CreateBoilerplateCli()
+	args := []string{
+		"boilerplate",
+		"--template-url",
+		templateFolder,
+		"--output-folder",
+		outputFolder,
+		"--non-interactive",
+	}
+	runErr := app.Run(args)
+	assert.Error(t, runErr, errors.PrintErrorWithStackTrace(runErr))
+	assert.Contains(t, runErr.Error(), "Did you misspell the URL")
+}

--- a/test-fixtures/regression-test/misspelled-git/boilerplate.yml
+++ b/test-fixtures/regression-test/misspelled-git/boilerplate.yml
@@ -1,0 +1,4 @@
+dependencies:
+  - name: guestbook
+    output-folder: './guestbook'
+    template-url: git@github.com/JDoe/guestbook.git//nginx?ref=v0.1.0


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Attempts to fix https://github.com/gruntwork-io/boilerplate/issues/120

Since it's impossible to catch all misspelled URL formats, this is a best effort attempt to catch the most common misspelling of using `git@github.com/ORG/REPO` instead of `git@github.com:ORG/REPO`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
- Updated error handling to output a more helpful error message if the template URL may include a typo for a Git URL.