### PR TITLE
Fix vpc-app default number of NAT Gateways

### DIFF
--- a/examples/for-production/terragrunt-architecture-catalog/templates/services/networking/vpc/boilerplate.yml
+++ b/examples/for-production/terragrunt-architecture-catalog/templates/services/networking/vpc/boilerplate.yml
@@ -58,7 +58,7 @@ variables:
   - name: AppVPCNumNATGateways
     description: Enter the number of NAT Gateways that should we deploy in this VPC (e.g. typically 1 for mgmt).
     type: int
-    default: 1
+    default: 3
 
   - name: AppVPCNumAvailabilityZones
     description: Enter the number of availability zones to use. Set to 0 to use all the availability zones in the region.


### PR DESCRIPTION
## Description

Fix default number of NAT Gateways deployed for the RefArch Application VPC (1 NAT --> 3 NATs)

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes

Fix default number of NAT Gateways deployed for RefArch App VPC
