### PR TITLE
Support lists of strings in for_each_reference

### DIFF
--- a/examples/for-learning-and-testing/dependencies-for-each-reference-list-of-strings/boilerplate.yml
+++ b/examples/for-learning-and-testing/dependencies-for-each-reference-list-of-strings/boilerplate.yml
@@ -1,0 +1,32 @@
+variables:
+  - name: accounts
+    description: The AWS accounts
+    type: map
+    default:
+      dev:
+        email: dev@example.com
+        id: 1111
+      stage:
+        email: stage@example.com
+        id: 2222
+      prod:
+        email: prod@example.com
+        id: 3333
+  - name: accountNames
+    description: The names of the accounts in the accounts variable
+    type: list
+    default: "{{ keysSorted .accounts }}"
+
+dependencies:
+  - name: loop-dependency-example
+    template-url: ../terraform
+    # Render this dependency once for each environment the user specifies
+    for_each_reference: accountNames
+    # Render the dependency to an output folder that includes the environment name
+    output-folder: "live/{{ .__each__ }}"
+    variables:
+      - name: ServerName
+        description: The name to use for the EC2 instance (for its Name tag)
+        type: string
+        # Use the environment name in the server name
+        default: "example-{{ .__each__ }}"

--- a/test-fixtures/examples-expected-output/dependencies-for-each-reference-list-of-strings/live/dev/main.tf
+++ b/test-fixtures/examples-expected-output/dependencies-for-each-reference-list-of-strings/live/dev/main.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_instance" "example" {
+  ami           = "ami-abcd1234"
+  instance_type = "t3.micro"
+
+  tags = {
+    Name = "example-dev"
+  }
+}

--- a/test-fixtures/examples-expected-output/dependencies-for-each-reference-list-of-strings/live/prod/main.tf
+++ b/test-fixtures/examples-expected-output/dependencies-for-each-reference-list-of-strings/live/prod/main.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_instance" "example" {
+  ami           = "ami-abcd1234"
+  instance_type = "t3.micro"
+
+  tags = {
+    Name = "example-prod"
+  }
+}

--- a/test-fixtures/examples-expected-output/dependencies-for-each-reference-list-of-strings/live/stage/main.tf
+++ b/test-fixtures/examples-expected-output/dependencies-for-each-reference-list-of-strings/live/stage/main.tf
@@ -1,0 +1,12 @@
+provider "aws" {
+  region = "us-east-1"
+}
+
+resource "aws_instance" "example" {
+  ami           = "ami-abcd1234"
+  instance_type = "t3.micro"
+
+  tags = {
+    Name = "example-stage"
+  }
+}

--- a/test-fixtures/examples-var-files/dependencies-for-each-reference-list-of-strings/vars.yml
+++ b/test-fixtures/examples-var-files/dependencies-for-each-reference-list-of-strings/vars.yml
@@ -1,0 +1,1 @@
+# Intentionally empty

--- a/variables/yaml_helpers.go
+++ b/variables/yaml_helpers.go
@@ -88,22 +88,24 @@ func UnmarshalListOfStrings(fields map[string]interface{}, fieldName string) ([]
 		return nil, nil
 	}
 
-	asYamlList, isYamlList := fieldAsYaml.([]interface{})
-	if !isYamlList {
-		return nil, errors.WithStackTrace(InvalidTypeForField{FieldName: fieldName, ExpectedType: "[]interface{}", ActualType: reflect.TypeOf(fieldAsYaml)})
-	}
+	switch asList := fieldAsYaml.(type) {
+	case []interface{}:
+		listOfStrings := []string{}
 
-	listOfStrings := []string{}
-
-	for _, asYaml := range asYamlList {
-		if valueAsString, isString := asYaml.(string); isString {
-			listOfStrings = append(listOfStrings, valueAsString)
-		} else {
-			return nil, errors.WithStackTrace(InvalidTypeForField{FieldName: fieldName, ExpectedType: "string", ActualType: reflect.TypeOf(asYamlList)})
+		for _, asYaml := range asList {
+			if valueAsString, isString := asYaml.(string); isString {
+				listOfStrings = append(listOfStrings, valueAsString)
+			} else {
+				return nil, errors.WithStackTrace(InvalidTypeForField{FieldName: fieldName, ExpectedType: "string", ActualType: reflect.TypeOf(asList)})
+			}
 		}
-	}
 
-	return listOfStrings, nil
+		return listOfStrings, nil
+	case []string:
+		return asList, nil
+	default:
+		return nil, errors.WithStackTrace(InvalidTypeForField{FieldName: fieldName, ExpectedType: "[]interface{} or []string", ActualType: reflect.TypeOf(fieldAsYaml)})
+	}
 }
 
 // Given a map of key:value pairs read from a Boilerplate YAML config file of the format:


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

This is a small work around to allow using lists of strings (rather than lists of `interface{}`) with `for_each_reference`. This makes it possible to do transformations on values (e.g., extract keys from a map into a list) and pass the output of the transformation into `for_each_reference`.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
