### PR TITLE
Fix slice parsing

### DIFF
--- a/cli/boilerplate_cli.go
+++ b/cli/boilerplate_cli.go
@@ -94,6 +94,13 @@ func CreateBoilerplateCli() *cli.App {
 		},
 	}
 
+	// We pass JSON/YAML content to various CLI flags, such as --var, and this JSON/YAML content may contain commas or
+	// other separators urfave/cli would treat as a slice separator, and would therefore break the value into multiple
+	// parts in the middle of the JSON/YAML, which is not what we want. So here, we disable the slice separator to
+	// avoid that issue. This means you have to pass --var multiple times to get multiple values, which is what we
+	// want anyway. See https://github.com/urfave/cli/issues/1134 for more details.
+	app.DisableSliceFlagSeparator = true
+
 	return app
 
 }

--- a/go.mod
+++ b/go.mod
@@ -20,7 +20,7 @@ require (
 	github.com/pterm/pterm v0.12.41
 	github.com/stretchr/testify v1.7.2
 	github.com/stuart-warren/yamlfmt v0.1.2
-	github.com/urfave/cli/v2 v2.8.1
+	github.com/urfave/cli/v2 v2.26.0
 	golang.org/x/crypto v0.0.0-20220427172511-eb4f295cb31f // indirect
 	golang.org/x/sys v0.0.0-20220517195934-5e4e11fc645e // indirect
 	golang.org/x/term v0.0.0-20220411215600-e5f449aeb171 // indirect
@@ -40,7 +40,7 @@ require (
 	github.com/atomicgo/cursor v0.0.1 // indirect
 	github.com/aws/aws-sdk-go v1.40.56 // indirect
 	github.com/bgentry/go-netrc v0.0.0-20140422174119-9fd32a8b3d3d // indirect
-	github.com/cpuguy83/go-md2man/v2 v2.0.1 // indirect
+	github.com/cpuguy83/go-md2man/v2 v2.0.2 // indirect
 	github.com/davecgh/go-spew v1.1.1 // indirect
 	github.com/golang/groupcache v0.0.0-20200121045136-8c9f03a8e57e // indirect
 	github.com/golang/protobuf v1.5.2 // indirect

--- a/go.sum
+++ b/go.sum
@@ -290,6 +290,8 @@ github.com/cpuguy83/go-md2man/v2 v2.0.0-20190314233015-f79a8a8ca69d/go.mod h1:ma
 github.com/cpuguy83/go-md2man/v2 v2.0.0/go.mod h1:maD7wRr/U5Z6m/iR4s+kqSMx2CaBsrgA7czyZG/E6dU=
 github.com/cpuguy83/go-md2man/v2 v2.0.1 h1:r/myEWzV9lfsM1tFLgDyu0atFtJ1fXn261LKYj/3DxU=
 github.com/cpuguy83/go-md2man/v2 v2.0.1/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
+github.com/cpuguy83/go-md2man/v2 v2.0.2 h1:p1EgwI/C7NhT0JmVkwCD2ZBK8j4aeHQX2pMHHBfMQ6w=
+github.com/cpuguy83/go-md2man/v2 v2.0.2/go.mod h1:tgQtvFlXSQOSOSIRvRPT7W67SCa46tRHOmNcaadrF8o=
 github.com/creack/pty v1.1.7/go.mod h1:lj5s0c3V2DBrqTV7llrYr5NG6My20zk30Fl46Y7DoTY=
 github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ33E=
 github.com/creack/pty v1.1.17 h1:QeVUsEDNrLBW4tMgZHvxy18sKtr6VI492kBhUfhDJNI=
@@ -869,6 +871,8 @@ github.com/urfave/cli v1.22.2/go.mod h1:Gos4lmkARVdJ6EkW0WaNv/tZAAMe9V7XWyB60NtX
 github.com/urfave/cli/v2 v2.3.0/go.mod h1:LJmUH05zAU44vOAcrfzZQKsZbVcdbOG8rtL3/XcUArI=
 github.com/urfave/cli/v2 v2.8.1 h1:CGuYNZF9IKZY/rfBe3lJpccSoIY1ytfvmgQT90cNOl4=
 github.com/urfave/cli/v2 v2.8.1/go.mod h1:Z41J9TPoffeoqP0Iza0YbAhGvymRdZAd2uPmZ5JxRdY=
+github.com/urfave/cli/v2 v2.26.0 h1:3f3AMg3HpThFNT4I++TKOejZO8yU55t3JnnSr4S4QEI=
+github.com/urfave/cli/v2 v2.26.0/go.mod h1:8qnjx1vcq5s2/wpsqoZFndg2CE5tNFyrTvS6SinrnYQ=
 github.com/vishvananda/netlink v0.0.0-20181108222139-023a6dafdcdf/go.mod h1:+SR5DhBJrl6ZM7CoCKvpw5BKroDKQ+PJqOg65H/2ktk=
 github.com/vishvananda/netlink v1.1.0/go.mod h1:cTgwzPIzzgDAYoQrMm0EdrjRUBkTqKYppBueQtXaqoE=
 github.com/vishvananda/netlink v1.1.1-0.20201029203352-d40f9887b852/go.mod h1:twkDnbuQxJYemMlGd4JFIcuhgX83tXhKS2B/PRMpOho=

--- a/integration-tests/slice_parsing_test.go
+++ b/integration-tests/slice_parsing_test.go
@@ -1,0 +1,48 @@
+package integration_tests
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/gruntwork-io/boilerplate/cli"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Test that we can pass --var values with commas and spaces, and that those are parsed as a single value, rather than
+// multiple.
+func TestSliceParsing(t *testing.T) {
+	t.Parallel()
+
+	templateFolder := "../test-fixtures/regression-test/slice-parsing"
+
+	outputFolder, err := os.MkdirTemp("", "boilerplate-test-output")
+	require.NoError(t, err)
+	defer os.RemoveAll(outputFolder)
+
+	mapValue := `{"key1":"value1","key2":"value2","key3":"value3"}`
+
+	app := cli.CreateBoilerplateCli()
+	args := []string{
+		"boilerplate",
+		"--template-url",
+		templateFolder,
+		"--output-folder",
+		outputFolder,
+		"--var",
+		fmt.Sprintf("MapValue=%s", mapValue),
+		"--non-interactive",
+	}
+
+	runErr := app.Run(args)
+	require.NoError(t, runErr)
+
+	outputPath := filepath.Join(outputFolder, "output.txt")
+
+	// Check the JSON we passed in via the CLI got through without any modifications
+	bytes, err := os.ReadFile(outputPath)
+	require.NoError(t, err)
+	assert.Equal(t, mapValue, string(bytes))
+}

--- a/test-fixtures/regression-test/slice-parsing/boilerplate.yml
+++ b/test-fixtures/regression-test/slice-parsing/boilerplate.yml
@@ -1,0 +1,4 @@
+variables:
+  - name: MapValue
+    description: A map value that will be passed in via a --var flag
+    type: map

--- a/test-fixtures/regression-test/slice-parsing/output.txt
+++ b/test-fixtures/regression-test/slice-parsing/output.txt
@@ -1,0 +1,1 @@
+{{ .MapValue | toJson }}


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

As per https://github.com/urfave/cli/issues/1134, `urfave/cli` allows you to pass in "slices" (CLI args that can have multiple values) via either:

1. Passing the arg multiple times: e.g., `--var first --var second --var third`.
2. Passing multiple values to the arg with a separator (default: comma): e.g., `--var first,second,third`.

This second behavior is problematic for boilerplate, as we allow you to pass JSON and YAML into `--var` values, and JSON and YAML can contain commas. So these JSON and YAML values were being broken up in the middle, which made them invalid... And the error message we got was super unhelpful:

```
yaml: line 1: did not find expected ',' or '}'
```

This PR disables the second type of slice parsing. I also added a regression test that would fail with the unhelpful error above before the PR and passes now after the PR.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
