### PR TITLE
LIB-80: Replace tfenv and tgswitch with mise

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -11,8 +11,8 @@ env: &env
     # Since we are running in docker, USER doesn't get set, so we need to set it explicitly
     USER: circleci
     # Mise ASDF defaults to using main.tf to determine the terraform version to use, so we need to
-		# override this to use the .terraform-version file instead.
-		ASDF_HASHICORP_TERRAFORM_VERSION_FILE: .terraform-version
+    # override this to use the .terraform-version file instead.
+    ASDF_HASHICORP_TERRAFORM_VERSION_FILE: .terraform-version
 
 defaults: &defaults
   resource_class: medium

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -1,8 +1,8 @@
 env: &env
   environment:
     GRUNTWORK_INSTALLER_VERSION: v0.0.36
-    MODULE_CI_VERSION: v0.53.3
-    TFENV_VERSION: v2.2.2
+    MODULE_CI_VERSION: v0.55.1
+    MISE_VERSION: v2024.4.0
     TERRAFORM_VERSION: 1.0.11
     TERRAGRUNT_VERSION: v0.36.1
     PACKER_VERSION: NONE
@@ -58,7 +58,7 @@ jobs:
             gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/terraform-aws-ci" --tag "${MODULE_CI_VERSION}"
             gruntwork-install --module-name "git-helpers" --repo "https://github.com/gruntwork-io/terraform-aws-ci" --tag "${MODULE_CI_VERSION}"
             configure-environment-for-gruntwork-module \
-              --tfenv-version ${TFENV_VERSION} \
+              --mise-version ${MISE_VERSION} \
               --terraform-version ${TERRAFORM_VERSION} \
               --terragrunt-version ${TERRAGRUNT_VERSION} \
               --packer-version ${PACKER_VERSION} \

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -10,6 +10,9 @@ env: &env
     GO111MODULE: auto
     # Since we are running in docker, USER doesn't get set, so we need to set it explicitly
     USER: circleci
+    # Mise ASDF defaults to using main.tf to determine the terraform version to use, so we need to
+		# override this to use the .terraform-version file instead.
+		ASDF_HASHICORP_TERRAFORM_VERSION_FILE: .terraform-version
 
 defaults: &defaults
   resource_class: medium

--- a/examples/for-production/terragrunt-architecture-catalog/templates/_root/infrastructure-live/boilerplate.yml
+++ b/examples/for-production/terragrunt-architecture-catalog/templates/_root/infrastructure-live/boilerplate.yml
@@ -24,11 +24,11 @@ variables:
     default: us-east-1
 
   - name: TerraformVersion
-    description: Used by the tfenv tool to automatically select which version of Terraform to use.
+    description: Used by the mise tool to automatically select which version of Terraform to use.
     default: 1.0.11
 
   - name: TerragruntVersion
-    description: Used by the tgswitch tool to automatically select which version of Terragrunt to use.
+    description: Used by the mise tool to automatically select which version of Terragrunt to use.
     default: v0.36.1
 
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

* Bump CI module to replace tfenv with mise
* Replace tfenv/tgswitch references with mise

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes

<!-- One-line description of the PR that can be included in the final release notes. -->
Removed tfenv/tgswitch references. Updated CI module ref to replace tfenv