### PR TITLE
Change listSlice to sliceList to align with docs

### DIFF
--- a/examples/for-learning-and-testing/template-helpers/sample.txt
+++ b/examples/for-learning-and-testing/template-helpers/sample.txt
@@ -15,4 +15,4 @@
 {{ true | ternary "foo" "bar" }}
 
 {{ $myList := list 1 2 3 4 5 -}}
-{{ listSlice $myList 1 3 }}
+{{ sliceList $myList 1 3 }}

--- a/render/template_helpers.go
+++ b/render/template_helpers.go
@@ -56,7 +56,7 @@ func CreateTemplateHelpers(templatePath string, opts *options.BoilerplateOptions
 	sprigFuncs := sprig.FuncMap()
 	// We rename a few sprig functions that overlap with boilerplate implementations. See DEPRECATED note on boilerplate
 	// functions below for more details.
-	sprigFuncs["listSlice"] = sprigFuncs["slice"]
+	sprigFuncs["sliceList"] = sprigFuncs["slice"]
 	sprigFuncs["replaceAll"] = sprigFuncs["replace"]
 	sprigFuncs["keysUnordered"] = sprigFuncs["keys"]
 	sprigFuncs["readEnv"] = sprigFuncs["env"]


### PR DESCRIPTION
## Description

No open issue for this and the fix was obvious enough. I have a feeling I'm the only one that's used this alias so far.

In the documentation this function alias is referred to as `sliceList`. When trying to use it I kept getting

```
function "sliceList" not defined
```

After going back and forth in the docs, double-checking my typing, copy-pasting from the docs, updating to the latest release, I eventually decided to dive into the code. Thankfully it was pretty obvious what went wrong here. I even went back to my template to verify that `listSlice` worked and it did! Hooray! Of course next release I'll need to change my `listSlice` to `sliceList`, but at least the code and docs will be aligned now :)

If you guys decide to go the other way and change the docs instead, or keep both `listSlice` and `sliceList` as aliases, feel free to close this PR and do the changes yourself or push commits to my branch. I've been very happy with the boilerplate so far, thanks so much for making and releasing it!

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs. _code is now aligned with the docs_
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
Added / Removed / Updated [X].

Fixed the alias to the Spring `slice` function. It was documented as `sliceList` but was implemented as `listSlice`.

### Migration Guide

Replace all usages of `listSlice` with `sliceList` instead.
