### PR TITLE
switch logging to slog

### DIFF
--- a/cli/boilerplate_cli.go
+++ b/cli/boilerplate_cli.go
@@ -96,6 +96,10 @@ func CreateBoilerplateCli() *cli.App {
 			Name:  options.OptDisableDependencyPrompt,
 			Usage: fmt.Sprintf("Do not prompt for confirmation to include dependencies. Has the same effect as --%s, without disabling variable prompts.", options.OptNonInteractive),
 		},
+		&cli.BoolFlag{
+			Name:  options.OptSilent,
+			Usage: "Do not output any log messages",
+		},
 	}
 
 	// We pass JSON/YAML content to various CLI flags, such as --var, and this JSON/YAML content may contain commas or

--- a/config/config.go
+++ b/config/config.go
@@ -41,10 +41,10 @@ func (config *BoilerplateConfig) GetVariablesMap() map[string]variables.Variable
 
 // Implement the go-yaml unmarshal interface for BoilerplateConfig. We can't let go-yaml handle this itself because:
 //
-// 1. Variable is an interface
-// 2. We need to provide Defaults for optional fields, such as "type"
-// 3. We want to validate the variable as part of the unmarshalling process so we never have invalid Variable or
-//    Dependency classes floating around
+//  1. Variable is an interface
+//  2. We need to provide Defaults for optional fields, such as "type"
+//  3. We want to validate the variable as part of the unmarshalling process so we never have invalid Variable or
+//     Dependency classes floating around
 func (config *BoilerplateConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var fields map[string]interface{}
 	if err := unmarshal(&fields); err != nil {
@@ -176,7 +176,7 @@ func LoadBoilerplateConfig(opts *options.BoilerplateOptions) (*BoilerplateConfig
 	configPath := BoilerplateConfigPath(opts.TemplateFolder)
 
 	if util.PathExists(configPath) {
-		util.Logger.Printf("Loading boilerplate config from %s", configPath)
+		opts.Logger.Info(fmt.Sprintf("Loading boilerplate config from %s", configPath))
 		bytes, err := ioutil.ReadFile(configPath)
 		if err != nil {
 			return nil, errors.WithStackTrace(err)
@@ -184,7 +184,7 @@ func LoadBoilerplateConfig(opts *options.BoilerplateOptions) (*BoilerplateConfig
 
 		return ParseBoilerplateConfig(bytes)
 	} else if opts.OnMissingConfig == options.Ignore {
-		util.Logger.Printf("Warning: boilerplate config file not found at %s. The %s flag is set, so ignoring. Note that no variables will be available while generating.", configPath, options.OptMissingConfigAction)
+		opts.Logger.Info(fmt.Sprintf("Warning: boilerplate config file not found at %s. The %s flag is set, so ignoring. Note that no variables will be available while generating.", configPath, options.OptMissingConfigAction))
 		return &BoilerplateConfig{}, nil
 	} else {
 		// If the template URL is similar to a git URL, surface in error message that there may be a misspelling/typo.

--- a/config/config_test.go
+++ b/config/config_test.go
@@ -2,7 +2,9 @@ package config
 
 import (
 	"bytes"
+	"io"
 	"io/ioutil"
+	"log/slog"
 	"path"
 	"path/filepath"
 	"reflect"
@@ -620,7 +622,10 @@ func TestParseBoilerplateConfigMultipleHooks(t *testing.T) {
 func TestLoadBoilerplateConfigFullConfig(t *testing.T) {
 	t.Parallel()
 
-	actual, err := LoadBoilerplateConfig(&options.BoilerplateOptions{TemplateFolder: "../test-fixtures/config-test/full-config"})
+	actual, err := LoadBoilerplateConfig(&options.BoilerplateOptions{
+		Logger:         slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		TemplateFolder: "../test-fixtures/config-test/full-config",
+	})
 	expected := &BoilerplateConfig{
 		Partials: []string{"../templates/foo"},
 		Variables: []variables.Variable{
@@ -664,7 +669,10 @@ func TestLoadBoilerplateConfigNoConfigIgnore(t *testing.T) {
 	t.Parallel()
 
 	templateFolder := "../test-fixtures/config-test/no-config"
-	actual, err := LoadBoilerplateConfig(&options.BoilerplateOptions{TemplateFolder: templateFolder, OnMissingConfig: options.Ignore})
+	actual, err := LoadBoilerplateConfig(&options.BoilerplateOptions{
+		Logger:         slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		TemplateFolder: templateFolder, OnMissingConfig: options.Ignore,
+	})
 	expected := &BoilerplateConfig{}
 
 	assert.Nil(t, err, "Unexpected error: %v", err)
@@ -674,7 +682,10 @@ func TestLoadBoilerplateConfigNoConfigIgnore(t *testing.T) {
 func TestLoadBoilerplateConfigInvalidConfig(t *testing.T) {
 	t.Parallel()
 
-	_, err := LoadBoilerplateConfig(&options.BoilerplateOptions{TemplateFolder: "../test-fixtures/config-test/invalid-config"})
+	_, err := LoadBoilerplateConfig(&options.BoilerplateOptions{
+		Logger:         slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		TemplateFolder: "../test-fixtures/config-test/invalid-config",
+	})
 
 	assert.NotNil(t, err)
 

--- a/config/get_variables.go
+++ b/config/get_variables.go
@@ -170,10 +170,10 @@ func getVariable(variable variables.Variable, opts *options.BoilerplateOptions) 
 	valueFromVars, valueSpecifiedInVars := getVariableFromVars(variable, opts)
 
 	if valueSpecifiedInVars {
-		util.Logger.Printf("Using value specified via command line options for variable '%s': %s", variable.FullName(), valueFromVars)
+		opts.Logger.Info(fmt.Sprintf("Using value specified via command line options for variable '%s': %s", variable.FullName(), valueFromVars))
 		return valueFromVars, nil
 	} else if opts.NonInteractive && variable.Default() != nil {
-		util.Logger.Printf("Using default value for variable '%s': %v", variable.FullName(), variable.Default())
+		opts.Logger.Info(fmt.Sprintf("Using default value for variable '%s': %v", variable.FullName(), variable.Default()))
 		return variable.Default(), nil
 	} else if opts.NonInteractive {
 		return nil, errors.WithStackTrace(MissingVariableWithNonInteractiveMode(variable.FullName()))
@@ -269,7 +269,7 @@ func getVariableFromUser(variable variables.Variable, opts *options.BoilerplateO
 
 	if value == "" {
 		// TODO: what if the user wanted an empty string instead of the default?
-		util.Logger.Printf("Using default value for variable '%s': %v", variable.FullName(), variable.Default())
+		opts.Logger.Info(fmt.Sprintf("Using default value for variable '%s': %v", variable.FullName(), variable.Default()))
 		return variable.Default(), nil
 	}
 

--- a/config/get_variables_test.go
+++ b/config/get_variables_test.go
@@ -1,6 +1,8 @@
 package config
 
 import (
+	"io"
+	"log/slog"
 	"reflect"
 	"testing"
 
@@ -15,7 +17,7 @@ func TestGetVariableFromVarsEmptyVars(t *testing.T) {
 	t.Parallel()
 
 	variable := variables.NewStringVariable("foo")
-	opts := &options.BoilerplateOptions{}
+	opts := &options.BoilerplateOptions{Logger: slog.New(slog.NewJSONHandler(io.Discard, nil))}
 
 	_, containsValue := getVariableFromVars(variable, opts)
 	assert.False(t, containsValue)
@@ -108,6 +110,7 @@ func TestGetVariableInVarsNonInteractive(t *testing.T) {
 
 	variable := variables.NewStringVariable("foo")
 	opts := &options.BoilerplateOptions{
+		Logger:         slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		NonInteractive: true,
 		Vars: map[string]interface{}{
 			"key1": "value1",
@@ -128,6 +131,7 @@ func TestGetVariableDefaultNonInteractive(t *testing.T) {
 
 	variable := variables.NewStringVariable("foo").WithDefault("bar")
 	opts := &options.BoilerplateOptions{
+		Logger:         slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		NonInteractive: true,
 		Vars: map[string]interface{}{
 			"key1": "value1",
@@ -225,6 +229,7 @@ func TestGetVariablesMatchFromVarsAndDefaults(t *testing.T) {
 	t.Parallel()
 
 	opts := &options.BoilerplateOptions{
+		Logger:         slog.New(slog.NewJSONHandler(io.Discard, nil)),
 		NonInteractive: true,
 		Vars: map[string]interface{}{
 			"key1": "value1",

--- a/getter-helper/getter_helper.go
+++ b/getter-helper/getter_helper.go
@@ -3,6 +3,7 @@ package getter_helper
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -12,7 +13,6 @@ import (
 	urlhelper "github.com/hashicorp/go-getter/helper/url"
 
 	"github.com/gruntwork-io/boilerplate/errors"
-	"github.com/gruntwork-io/boilerplate/util"
 )
 
 var forcedRegexp = regexp.MustCompile(`^([A-Za-z0-9]+)::(.+)$`)
@@ -100,7 +100,7 @@ func NewGetterClient(src string, dst string) (*getter.Client, error) {
 // DownloadTemplatesToTemporaryFolder uses the go-getter library to fetch the templates from the configured URL to a
 // temporary folder and returns the path to that folder. If there is a subdir in the template URL, return the combined
 // path as well.
-func DownloadTemplatesToTemporaryFolder(templateUrl string) (string, string, error) {
+func DownloadTemplatesToTemporaryFolder(templateUrl string, logger *slog.Logger) (string, string, error) {
 	workingDir, err := getTempFolder()
 	if err != nil {
 		return workingDir, workingDir, errors.WithStackTrace(err)
@@ -109,7 +109,7 @@ func DownloadTemplatesToTemporaryFolder(templateUrl string) (string, string, err
 	// Always set a subdir path because go-getter can not clone into an existing dir.
 	cloneDir := filepath.Join(workingDir, "wd")
 
-	util.Logger.Printf("Downloading templates from %s to %s", templateUrl, workingDir)
+	logger.Info(fmt.Sprintf("Downloading templates from %s to %s", templateUrl, workingDir))
 
 	// If there is a subdir component, we download everything and combine the path at the end to return the working path
 	mainPath, subDir := getter.SourceDirSubdir(templateUrl)

--- a/getter-helper/getter_helper_unix_test.go
+++ b/getter-helper/getter_helper_unix_test.go
@@ -5,6 +5,8 @@ package getter_helper
 
 import (
 	"fmt"
+	"io"
+	"log/slog"
 	"os"
 	"path/filepath"
 	"testing"
@@ -24,7 +26,7 @@ func TestDownloadTemplatesToTempDir(t *testing.T) {
 
 	branch := git.GetCurrentBranchName(t)
 	templateUrl := fmt.Sprintf("git@github.com:gruntwork-io/boilerplate.git//examples/for-learning-and-testing/variables?ref=%s", branch)
-	workingDir, workPath, err := DownloadTemplatesToTemporaryFolder(templateUrl)
+	workingDir, workPath, err := DownloadTemplatesToTemporaryFolder(templateUrl, slog.New(slog.NewJSONHandler(io.Discard, nil)))
 	defer os.RemoveAll(workingDir)
 	require.NoError(t, err, errors.PrintErrorWithStackTrace(err))
 

--- a/go.mod
+++ b/go.mod
@@ -1,6 +1,6 @@
 module github.com/gruntwork-io/boilerplate
 
-go 1.18
+go 1.21
 
 require (
 	github.com/AlecAivazis/survey/v2 v2.3.4

--- a/integration-tests/error_message_test.go
+++ b/integration-tests/error_message_test.go
@@ -28,6 +28,7 @@ func TestMisspelledTemplateURLErrorMessage(t *testing.T) {
 		"--output-folder",
 		outputFolder,
 		"--non-interactive",
+		"--silent",
 	}
 	runErr := app.Run(args)
 	assert.Error(t, runErr, errors.PrintErrorWithStackTrace(runErr))

--- a/integration-tests/examples_test.go
+++ b/integration-tests/examples_test.go
@@ -138,6 +138,7 @@ func testExample(t *testing.T, templateFolder string, outputFolder string, varFi
 		"--non-interactive",
 		"--missing-key-action",
 		missingKeyAction,
+		"--silent",
 	}
 
 	// Special handling for the shell-disabled case, which we use to test that we can disable hooks and shell helpers

--- a/integration-tests/required_version_test.go
+++ b/integration-tests/required_version_test.go
@@ -69,6 +69,7 @@ func runRequiredVersionExample(t *testing.T, templateFolder string) error {
 		"--output-folder",
 		outputPath,
 		"--non-interactive",
+		"--silent",
 	}
 	return app.Run(args)
 }

--- a/integration-tests/slice_parsing_test.go
+++ b/integration-tests/slice_parsing_test.go
@@ -34,6 +34,7 @@ func TestSliceParsing(t *testing.T) {
 		"--var",
 		fmt.Sprintf("MapValue=%s", mapValue),
 		"--non-interactive",
+		"--silent",
 	}
 
 	runErr := app.Run(args)

--- a/options/options.go
+++ b/options/options.go
@@ -2,6 +2,7 @@ package options
 
 import (
 	"fmt"
+	"log/slog"
 
 	"github.com/urfave/cli/v2"
 
@@ -20,6 +21,7 @@ const OptMissingConfigAction = "missing-config-action"
 const OptDisableHooks = "disable-hooks"
 const OptDisableShell = "disable-shell"
 const OptDisableDependencyPrompt = "disable-dependency-prompt"
+const OptSilent = "silent"
 
 // The command-line options for the boilerplate app
 type BoilerplateOptions struct {
@@ -36,6 +38,8 @@ type BoilerplateOptions struct {
 	DisableHooks            bool
 	DisableShell            bool
 	DisableDependencyPrompt bool
+	Silent                  bool
+	Logger                  *slog.Logger
 }
 
 // Validate that the options have reasonable values and return an error if they don't
@@ -96,6 +100,7 @@ func ParseOptions(cliContext *cli.Context) (*BoilerplateOptions, error) {
 		DisableHooks:            cliContext.Bool(OptDisableHooks),
 		DisableShell:            cliContext.Bool(OptDisableShell),
 		DisableDependencyPrompt: cliContext.Bool(OptDisableDependencyPrompt),
+		Silent:                  cliContext.Bool(OptSilent),
 	}
 
 	if err := options.Validate(); err != nil {

--- a/render/template_helpers.go
+++ b/render/template_helpers.go
@@ -255,7 +255,8 @@ func include(templatePath string, opts *options.BoilerplateOptions, path string,
 // Example:
 //
 // pathRelativeToTemplate("/foo/bar/template-file.txt, "../src/code.java")
-//   Returns: "/foo/src/code.java"
+//
+//	Returns: "/foo/src/code.java"
 func PathRelativeToTemplate(templatePath string, filePath string) string {
 	if path.IsAbs(filePath) {
 		return filePath
@@ -606,7 +607,7 @@ func keys(value interface{}) ([]string, error) {
 // string.
 func shell(templatePath string, opts *options.BoilerplateOptions, rawArgs ...string) (string, error) {
 	if opts.DisableShell {
-		util.Logger.Printf("Shell helpers are disabled. Will not execute shell command '%v'. Returning placeholder value '%s' instead.", rawArgs, SHELL_DISABLED_PLACEHOLDER)
+		opts.Logger.Info(fmt.Sprintf("Shell helpers are disabled. Will not execute shell command '%v'. Returning placeholder value '%s' instead.", rawArgs, SHELL_DISABLED_PLACEHOLDER))
 		return SHELL_DISABLED_PLACEHOLDER, nil
 	}
 

--- a/render/template_helpers_test.go
+++ b/render/template_helpers_test.go
@@ -4,6 +4,8 @@ import (
 	"bufio"
 	"bytes"
 	"fmt"
+	"io"
+	"log/slog"
 	"path/filepath"
 	"reflect"
 	"runtime"
@@ -473,7 +475,11 @@ func TestShellError(t *testing.T) {
 func TestShellDisabled(t *testing.T) {
 	t.Parallel()
 
-	output, err := shell(".", &options.BoilerplateOptions{NonInteractive: true, DisableShell: true}, "echo", "hi")
+	output, err := shell(".", &options.BoilerplateOptions{
+		Logger:         slog.New(slog.NewJSONHandler(io.Discard, nil)),
+		NonInteractive: true,
+		DisableShell:   true,
+	}, "echo", "hi")
 	assert.Nil(t, err, "Unexpected error: %v", err)
 	assert.Equal(t, SHELL_DISABLED_PLACEHOLDER, output)
 }

--- a/templates/engines_processor.go
+++ b/templates/engines_processor.go
@@ -29,7 +29,7 @@ func processEngines(
 		if err != nil {
 			return nil, err
 		}
-		debugLogForMatchedPaths(engine.Path, matchedPaths, "Engine", "Path")
+		debugLogForMatchedPaths(engine.Path, matchedPaths, "Engine", "Path", opts.Logger)
 
 		processedEngine := ProcessedEngine{
 			EvaluatedPaths: matchedPaths,

--- a/util/logger.go
+++ b/util/logger.go
@@ -1,9 +1,0 @@
-package util
-
-import (
-	"log"
-	"os"
-)
-
-// A simple logger we can use to get consistent log formatting through out the app
-var Logger = log.New(os.Stdout, "[boilerplate] ", log.LstdFlags)

--- a/util/prefixer/prefixer.go
+++ b/util/prefixer/prefixer.go
@@ -1,0 +1,50 @@
+package prefixer
+
+import (
+	"bytes"
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"sync"
+)
+
+type Handler struct {
+	h      slog.Handler
+	m      *sync.Mutex
+	writer io.Writer
+}
+
+func (h *Handler) Enabled(ctx context.Context, level slog.Level) bool {
+	return h.h.Enabled(ctx, level)
+}
+
+func (h *Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return &Handler{h: h.h.WithAttrs(attrs), m: h.m, writer: h.writer}
+}
+
+func (h *Handler) WithGroup(name string) slog.Handler {
+	return &Handler{h: h.h.WithGroup(name), m: h.m, writer: h.writer}
+}
+
+func (h *Handler) Handle(ctx context.Context, r slog.Record) error {
+	msg := slog.StringValue(r.Message).String()
+	if msg != "" {
+		_, err := io.WriteString(h.writer, fmt.Sprintf("[boilerplate] %s\n", msg))
+		return err
+	}
+
+	return nil
+}
+
+func New() *Handler {
+	buf := &bytes.Buffer{}
+	handler := &Handler{
+		h:      slog.NewTextHandler(buf, &slog.HandlerOptions{}),
+		m:      &sync.Mutex{},
+		writer: os.Stdout,
+	}
+
+	return handler
+}

--- a/util/shell.go
+++ b/util/shell.go
@@ -3,14 +3,13 @@ package util
 import (
 	"os"
 	"os/exec"
-	"strings"
 
 	"github.com/gruntwork-io/boilerplate/errors"
 )
 
 // Run the given shell command with the given environment variables and arguments in the given working directory
 func RunShellCommandAndGetOutput(workingDir string, envVars []string, command string, args ...string) (string, error) {
-	Logger.Printf("Running command: %s %s", command, strings.Join(args, " "))
+	// Logger.Info(fmt.Sprintf("Running command: %s %s", command, strings.Join(args, " ")))
 
 	cmd := exec.Command(command, args...)
 
@@ -28,7 +27,7 @@ func RunShellCommandAndGetOutput(workingDir string, envVars []string, command st
 
 // Run the given shell command with the given environment variables and arguments in the given working directory
 func RunShellCommand(workingDir string, envVars []string, command string, args ...string) error {
-	Logger.Printf("Running command: %s %s", command, strings.Join(args, " "))
+	// Logger.Info(fmt.Sprintf("Running command: %s %s", command, strings.Join(args, " ")))
 
 	cmd := exec.Command(command, args...)
 


### PR DESCRIPTION
## Description

Fixes #82.

Currently all logging is done via `utils.Logger` which just outputs logging to `stdout`.  It would be nice to have more control over logging by silencing logging when not needed or injecting a separate logger (compatible with `*slog.Logger`). 

There is a lot of lines of change here, but it's just creating a `slog.Handler` that prefixes `[boilerplate]` to log lines to maintain the existing look and passing an instance of the logger throughout.  `go` is not my primary language though, any feedback is greatly appreciated!

NOTE: This does bump the minimum go version to `1.21`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated logging to use `slog` library.

### Migration Guide

None
