### PR TITLE
[CI] Skip test_signing Job on Release Tag Push

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -242,7 +242,7 @@ workflows:
             branches:
               only: /.*/
             tags:
-              only: /.*/
+              ignore: /^v.*/
       - deploy:
           requires:
             - test


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

CI config update to skip `test_signing` job on release tag push. 

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

<!-- One-line description of the PR that can be included in the final release notes. -->
- CircleCI config changes only.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
