### PR TITLE
fix: Moving to `main`

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -57,7 +57,7 @@ jobs:
           name: install dependencies
           command: |
             # Install the gruntwork-module-circleci-helpers and use it to configure the build environment and run tests.
-            curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version "${GRUNTWORK_INSTALLER_VERSION}"
+            curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/main/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version "${GRUNTWORK_INSTALLER_VERSION}"
             gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/terraform-aws-ci" --tag "${MODULE_CI_VERSION}"
             gruntwork-install --module-name "git-helpers" --repo "https://github.com/gruntwork-io/terraform-aws-ci" --tag "${MODULE_CI_VERSION}"
             configure-environment-for-gruntwork-module \
@@ -150,7 +150,7 @@ jobs:
       - run:
           name: Install sign-binary-helpers
           command: |
-            curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version "${GRUNTWORK_INSTALLER_VERSION}"
+            curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/main/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version "${GRUNTWORK_INSTALLER_VERSION}"
             gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/terraform-aws-ci" --tag "${MODULE_CI_VERSION}"
             gruntwork-install --module-name "sign-binary-helpers" --repo "https://github.com/gruntwork-io/terraform-aws-ci" --tag "${MODULE_CI_VERSION}"
       - run:
@@ -184,7 +184,7 @@ jobs:
       - run:
           name: Install sign-binary-helpers
           command: |
-            curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/master/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version "${GRUNTWORK_INSTALLER_VERSION}"
+            curl -Ls https://raw.githubusercontent.com/gruntwork-io/gruntwork-installer/main/bootstrap-gruntwork-installer.sh | bash /dev/stdin --version "${GRUNTWORK_INSTALLER_VERSION}"
             gruntwork-install --module-name "gruntwork-module-circleci-helpers" --repo "https://github.com/gruntwork-io/terraform-aws-ci" --tag "${MODULE_CI_VERSION}"
             gruntwork-install --module-name "sign-binary-helpers" --repo "https://github.com/gruntwork-io/terraform-aws-ci" --tag "${MODULE_CI_VERSION}"
       - run:

--- a/README.md
+++ b/README.md
@@ -169,7 +169,7 @@ The `boilerplate` binary supports the following options:
 
 * `--template-url URL` (required): Generate the project from the templates in `URL`. This can be a local path, or a
   [go-getter](https://github.com/hashicorp/go-getter) compatible URL for remote templates (e.g.,
-  `git@github.com:gruntwork-io/boilerplate.git//examples/for-learning-and-testing/include?ref=master`).
+  `git@github.com:gruntwork-io/boilerplate.git//examples/for-learning-and-testing/include?ref=main`).
 * `--output-folder` (required): Create the output files and folders in `FOLDER`.
 * `--non-interactive` (optional): Do not prompt for input variables. All variables must be set via `--var` and
   `--var-file` options instead.
@@ -211,7 +211,7 @@ boilerplate --template-url ~/templates --output-folder ~/output --var-file vars.
 Generate a project in ~/output from the templates in this repo's `include` example dir, using variables read from a file:
 
 ```
-boilerplate --template-url "git@github.com:gruntwork-io/boilerplate.git//examples/for-learning-and-testing/include?ref=master" --output-folder ~/output --var-file vars.yml
+boilerplate --template-url "git@github.com:gruntwork-io/boilerplate.git//examples/for-learning-and-testing/include?ref=main" --output-folder ~/output --var-file vars.yml
 ```
 
 

--- a/cli/boilerplate_cli.go
+++ b/cli/boilerplate_cli.go
@@ -30,7 +30,7 @@ Generate a project in ~/output from the templates in ~/templates, using variable
 
 Generate a project in ~/output from the templates in this repo's include example dir, using variables read from a file:
 
-	boilerplate --template-url "git@github.com:gruntwork-io/boilerplate.git//examples/for-learning-and-testing/include?ref=master" --output-folder ~/output --var-file vars.yml
+	boilerplate --template-url "git@github.com:gruntwork-io/boilerplate.git//examples/for-learning-and-testing/include?ref=main" --output-folder ~/output --var-file vars.yml
 
 
 Options:
@@ -58,7 +58,7 @@ func CreateBoilerplateCli() *cli.App {
 	app.Flags = []cli.Flag{
 		&cli.StringFlag{
 			Name:  options.OptTemplateUrl,
-			Usage: "Generate the project from the templates in `URL`. This can be a local path, or a go-getter compatible URL for remote templates (e.g., `git@github.com:gruntwork-io/boilerplate.git//examples/for-learning-and-testing/include?ref=master`).",
+			Usage: "Generate the project from the templates in `URL`. This can be a local path, or a go-getter compatible URL for remote templates (e.g., `git@github.com:gruntwork-io/boilerplate.git//examples/for-learning-and-testing/include?ref=main`).",
 		},
 		&cli.StringFlag{
 			Name:  options.OptOutputFolder,

--- a/examples/for-learning-and-testing/dependencies-remote/boilerplate.yml
+++ b/examples/for-learning-and-testing/dependencies-remote/boilerplate.yml
@@ -18,7 +18,7 @@ variables:
 
   - name: RemoteBranch
     description: The branch of boilerplate repo to use when pulling down remote dependencies.
-    default: "master"
+    default: "main"
 
 dependencies:
   - name: docs


### PR DESCRIPTION
## Description

To stay consistent with what's used on other Gruntwork projects, let's move the default branch to `main`. After merging this, I'll use GitHub functionality to rename the `master` branch to `main`.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated references of `master` to `main`.

