### PR TITLE
fix: Updating CODEOWNERS

### DIFF
--- a/CODEOWNERS
+++ b/CODEOWNERS
@@ -1,1 +1,5 @@
-* @brikis98 @hongil0316
+# GRUNTWORK CODEOWNERS FILE
+# Gruntwork sets the codeowner for its repositories to the machine user `gruntwork-codeowner`. 
+# We use an internal process for triaging all incoming issues and pull requests and that process will end up setting an assignee for any new issues.
+
+* @gruntwork-codeowner


### PR DESCRIPTION
## Description

Using standard CODEOWNERS file used in Gruntwork projects.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated `CODEOWNERS` file to use standard Gruntwork CODEOWNERS file.

