### PR TITLE
Fix manual input should support bools

### DIFF
--- a/config/get_variables.go
+++ b/config/get_variables.go
@@ -203,7 +203,7 @@ func getVariableFromUser(variable variables.Variable, opts *options.BoilerplateO
 	value := ""
 	// Display rich prompts to the user, based on the type of variable we're asking for
 	switch variable.Type() {
-	case variables.String, variables.Int, variables.Float, variables.Bool:
+	case variables.String, variables.Int, variables.Float, variables.Bool, variables.List, variables.Map:
 		msg := fmt.Sprintf("Enter a value [type %s]", variable.Type())
 		if variable.Default() != nil {
 			msg = fmt.Sprintf("%s (default: %v)", msg, variable.Default())
@@ -229,6 +229,14 @@ func getVariableFromUser(variable variables.Variable, opts *options.BoilerplateO
 				log.Fatal("quit")
 			}
 			return value, err
+		}
+	default:
+		if variable.Default() == nil {
+			fmt.Println()
+			msg := fmt.Sprintf("Variable %s of type '%s' does not support manual input and has no default value.\n"+
+				"Please update the variable in the boilerplate.yml file to include a default value or provide a value via the command line using the --var option.",
+				pterm.Green(variable.FullName()), variable.Type())
+			log.Fatal(msg)
 		}
 	}
 

--- a/go.mod
+++ b/go.mod
@@ -30,6 +30,7 @@ require (
 require (
 	github.com/gabriel-vasile/mimetype v1.4.6
 	github.com/google/go-cmp v0.6.0
+	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c
 )
 
 require (
@@ -112,7 +113,6 @@ require (
 	go.opentelemetry.io/otel/sdk v1.31.0 // indirect
 	go.opentelemetry.io/otel/sdk/metric v1.31.0 // indirect
 	go.opentelemetry.io/otel/trace v1.31.0 // indirect
-	golang.org/x/exp v0.0.0-20241009180824-f66d83c29e7c // indirect
 	golang.org/x/net v0.30.0 // indirect
 	golang.org/x/oauth2 v0.23.0 // indirect
 	golang.org/x/sync v0.8.0 // indirect


### PR DESCRIPTION
## Description

Fixes #201 #170

Fix manual input to include types other than strings and enums. Validate that a manual input is provided if no default is defined on the variable. Validate that the input can be parsed to the correct type and if not re-prompt the user.

## Release Notes (draft)

- Added support for manual inputs other than strings or enums. The command line will now prompt the user for input for `int`, `float`, `bool`, `list`, and `map` variable types.
- Fixed manual input using `<no value>` if a default does not exist. User will be prompted again instead.
- Changed the visual appearance of the manual input to closer match the example.

![image](https://github.com/user-attachments/assets/d25c2224-bab9-42a1-b949-3a24669468e6)


### Migration Guide

This change will cause users to be prompted for more types of variables, and may find that they are required to populate Default values in more situations. If you have been relying on a variable that will now require manual input, but you want to use the Default, you will need to add the `--non-interactive` flag to prevent the prompt.