### PR TITLE
feat: add fromYaml to template helpers.

### DIFF
--- a/README.md
+++ b/README.md
@@ -873,6 +873,7 @@ Boilerplate also includes several custom helpers that you can access that enhanc
 * `templateIsDefined NAME`: Returns a boolean indicating if template called `NAME` is known. Use this to conditionally
   include one boilerplate template with another. Most often useful along with [partials](#partials).
 * `toYaml`: Encodes an input variable as a YAML string. Similar to the `toJson` function in sprig.
+* `fromYaml`: Decodes an input YAML string into a structure. Similar to the `fromJson` function in sprig.
 
 #### Deprecated helpers
 

--- a/render/template_helpers.go
+++ b/render/template_helpers.go
@@ -82,6 +82,7 @@ func CreateTemplateHelpers(templatePath string, opts *options.BoilerplateOptions
 		"trimPrefixBoilerplate": trimPrefix,
 		"trimSuffixBoilerplate": trimSuffix,
 		"toYaml":                toYaml,
+		"fromYaml":              fromYaml,
 
 		"numRange":   slice,
 		"keysSorted": keys,
@@ -654,6 +655,15 @@ func toYaml(obj interface{}) (string, error) {
 		return "", errors.WithStackTrace(err)
 	}
 	return string(yamlObj), nil
+}
+
+func fromYaml(yamlStr string) (interface{}, error) {
+	var obj interface{}
+	err := yaml.Unmarshal([]byte(yamlStr), &obj)
+	if err != nil {
+		return nil, errors.WithStackTrace(err)
+	}
+	return obj, nil
 }
 
 // Returns the relative path between the output folders of a "base" path and a "target" path.


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Add fromYaml function to template helpers.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [x] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Add fromYaml function to template helpers.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
