### PR TITLE
allow parallel dependency processing.

### DIFF
--- a/cli/boilerplate_cli.go
+++ b/cli/boilerplate_cli.go
@@ -96,6 +96,10 @@ func CreateBoilerplateCli() *cli.App {
 			Name:  options.OptDisableDependencyPrompt,
 			Usage: fmt.Sprintf("Do not prompt for confirmation to include dependencies. Has the same effect as --%s, without disabling variable prompts.", options.OptNonInteractive),
 		},
+		&cli.BoolFlag{
+			Name:  options.OptParallelForEach,
+			Usage: "If this flag is set, for_each'd dependencies will be processed in parallel instead of sequentially. This can significantly speed up template generation when dependencies take time to process. WARNING: Ensure that shell commands/hooks within dependencies are thread-safe, as multiple dependencies may execute concurrently.",
+		},
 	}
 
 	// We pass JSON/YAML content to various CLI flags, such as --var, and this JSON/YAML content may contain commas or

--- a/integration-tests/parallel_processing_test.go
+++ b/integration-tests/parallel_processing_test.go
@@ -1,0 +1,206 @@
+package integration_tests
+
+import (
+	"os"
+	"path"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/boilerplate/cli"
+)
+
+// Test that parallel processing produces the same output as sequential processing
+func TestParallelProcessingProducesSameOutput(t *testing.T) {
+	t.Parallel()
+
+	templateFolder := "../examples/for-learning-and-testing/dependencies-for-each"
+	varFile := "../test-fixtures/examples-var-files/dependencies-for-each/vars.yml"
+
+	sequentialOutput, err := os.MkdirTemp("", "boilerplate-test-sequential")
+	require.NoError(t, err)
+	defer os.RemoveAll(sequentialOutput)
+
+	parallelOutput, err := os.MkdirTemp("", "boilerplate-test-parallel")
+	require.NoError(t, err)
+	defer os.RemoveAll(parallelOutput)
+
+	// Run both sequential and parallel processing
+	runBoilerplateWithParallelFlag(t, templateFolder, sequentialOutput, varFile, false)
+	runBoilerplateWithParallelFlag(t, templateFolder, parallelOutput, varFile, true)
+
+	// Compare outputs - they should be identical
+	assertDirectoriesEqual(t, sequentialOutput, parallelOutput)
+}
+
+
+
+// Test that parallel processing handles errors correctly from multiple dependencies
+func TestParallelProcessingErrorHandling(t *testing.T) {
+	t.Parallel()
+
+	templateDir := createFailingTemplate(t)
+	defer os.RemoveAll(templateDir)
+
+	outputDir, err := os.MkdirTemp("", "boilerplate-error-output")
+	require.NoError(t, err)
+	defer os.RemoveAll(outputDir)
+
+	// Run with parallel processing - should fail but handle errors gracefully
+	app := cli.CreateBoilerplateCli()
+	args := []string{
+		"boilerplate",
+		"--template-url", templateDir,
+		"--output-folder", outputDir,
+		"--non-interactive",
+		"--parallel-for-each",
+	}
+
+	err = app.Run(args)
+	assert.Error(t, err)
+	assert.Contains(t, err.Error(), "nonexistent-template")
+}
+
+
+
+// Test that the --parallel-for-each flag is properly propagated to nested dependencies
+func TestParallelFlagPropagation(t *testing.T) {
+	t.Parallel()
+
+	templateDir := createNestedTemplate(t)
+	defer os.RemoveAll(templateDir)
+
+	outputDir, err := os.MkdirTemp("", "boilerplate-propagation-output")
+	require.NoError(t, err)
+	defer os.RemoveAll(outputDir)
+
+	// Run with parallel processing
+	runBoilerplateWithParallelFlag(t, templateDir, outputDir, "", true)
+
+	// Verify that all nested files were created
+	expectedPaths := []string{
+		"parent/parent1/child/child1/result.txt",
+		"parent/parent1/child/child2/result.txt", 
+		"parent/parent1/child/child3/result.txt",
+		"parent/parent2/child/child1/result.txt",
+		"parent/parent2/child/child2/result.txt",
+		"parent/parent2/child/child3/result.txt",
+	}
+
+	for _, expectedPath := range expectedPaths {
+		fullPath := path.Join(outputDir, expectedPath)
+		assert.FileExists(t, fullPath, "Nested file should exist at %s", expectedPath)
+	}
+}
+
+
+
+// Helper function to run boilerplate with or without parallel flag
+func runBoilerplateWithParallelFlag(t *testing.T, templateFolder, outputFolder, varFile string, parallel bool) {
+	app := cli.CreateBoilerplateCli()
+	
+	args := []string{
+		"boilerplate",
+		"--template-url", templateFolder,
+		"--output-folder", outputFolder,
+		"--non-interactive",
+	}
+
+	if varFile != "" {
+		args = append(args, "--var-file", varFile)
+	}
+
+	if parallel {
+		args = append(args, "--parallel-for-each")
+	}
+
+	err := app.Run(args)
+	require.NoError(t, err, "Boilerplate execution should succeed")
+}
+
+
+
+// Helper function to create a template that will cause failures
+func createFailingTemplate(t *testing.T) string {
+	templateDir, err := os.MkdirTemp("", "boilerplate-error-test")
+	require.NoError(t, err)
+
+	boilerplateConfig := `dependencies:
+  - name: failing-dependency-1
+    template-url: ./nonexistent-template-1
+    for_each:
+      - item1
+      - item2
+    output-folder: "output/{{ .__each__ }}"
+  - name: failing-dependency-2
+    template-url: ./nonexistent-template-2
+    for_each:
+      - item3
+      - item4
+    output-folder: "output/{{ .__each__ }}"
+`
+
+	err = os.WriteFile(path.Join(templateDir, "boilerplate.yml"), []byte(boilerplateConfig), 0o644)
+	require.NoError(t, err)
+
+	return templateDir
+}
+
+
+
+// Helper function to create a template with nested dependencies
+func createNestedTemplate(t *testing.T) string {
+	templateDir, err := os.MkdirTemp("", "boilerplate-propagation-test")
+	require.NoError(t, err)
+
+	// Create main template with for_each dependency
+	err = os.WriteFile(path.Join(templateDir, "boilerplate.yml"), []byte(`dependencies:
+  - name: parent-dependency
+    template-url: ./nested-template
+    for_each:
+      - parent1
+      - parent2
+    output-folder: "parent/{{ .__each__ }}"
+`), 0o644)
+	require.NoError(t, err)
+
+	// Create nested template directory
+	nestedTemplateDir := path.Join(templateDir, "nested-template")
+	err = os.MkdirAll(nestedTemplateDir, 0o755)
+	require.NoError(t, err)
+
+	// Create nested template with its own for_each dependencies
+	err = os.WriteFile(path.Join(nestedTemplateDir, "boilerplate.yml"), []byte(`dependencies:
+  - name: child-dependency
+    template-url: ./child-template
+    for_each:
+      - child1
+      - child2
+      - child3
+    output-folder: "child/{{ .__each__ }}"
+variables:
+  - name: ParentName
+    default: "{{ .__each__ }}"
+`), 0o644)
+	require.NoError(t, err)
+
+	// Create child template directory
+	childTemplateDir := path.Join(nestedTemplateDir, "child-template")
+	err = os.MkdirAll(childTemplateDir, 0o755)
+	require.NoError(t, err)
+
+	// Create simple child template
+	err = os.WriteFile(path.Join(childTemplateDir, "boilerplate.yml"), []byte(`variables:
+  - name: ChildName
+    default: "{{ .__each__ }}"
+`), 0o644)
+	require.NoError(t, err)
+
+	err = os.WriteFile(path.Join(childTemplateDir, "result.txt"), []byte(`Parent: {{ .ParentName }}
+Child: {{ .ChildName }}
+`), 0o644)
+	require.NoError(t, err)
+
+	return templateDir
+} 

--- a/options/options.go
+++ b/options/options.go
@@ -20,6 +20,7 @@ const OptMissingConfigAction = "missing-config-action"
 const OptDisableHooks = "disable-hooks"
 const OptDisableShell = "disable-shell"
 const OptDisableDependencyPrompt = "disable-dependency-prompt"
+const OptParallelForEach = "parallel-for-each"
 
 // The command-line options for the boilerplate app
 type BoilerplateOptions struct {
@@ -36,6 +37,7 @@ type BoilerplateOptions struct {
 	DisableHooks            bool
 	DisableShell            bool
 	DisableDependencyPrompt bool
+	ParallelForEach         bool
 }
 
 // Validate that the options have reasonable values and return an error if they don't
@@ -96,6 +98,7 @@ func ParseOptions(cliContext *cli.Context) (*BoilerplateOptions, error) {
 		DisableHooks:            cliContext.Bool(OptDisableHooks),
 		DisableShell:            cliContext.Bool(OptDisableShell),
 		DisableDependencyPrompt: cliContext.Bool(OptDisableDependencyPrompt),
+		ParallelForEach:         cliContext.Bool(OptParallelForEach),
 	}
 
 	if err := options.Validate(); err != nil {


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #232

Allows optional parallel processing of dependencies.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added optional parallel processing of dependencies via `--parallel-for-each` flag to improve performance when processing multiple dependency iterations.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
