### PR TITLE
Allow json var files

### DIFF
--- a/README.md
+++ b/README.md
@@ -174,7 +174,7 @@ The `boilerplate` binary supports the following options:
 * `--non-interactive` (optional): Do not prompt for input variables. All variables must be set via `--var` and
   `--var-file` options instead.
 * `--var NAME=VALUE` (optional): Use `NAME=VALUE` to set variable `NAME` to `VALUE`. May be specified more than once.
-* `--var-file FILE` (optional): Load variable values from the YAML file `FILE`. May be specified more than once.
+* `--var-file FILE` (optional): Load variable values from the YAML or JSON file `FILE`. May be specified more than once.
 * `--missing-key-action ACTION` (optional): What to do if a template looks up a variable that is not defined. Must
   be one of: `invalid` (render the text "<no value>"), `zero` (render the zero value for the variable), or `error`
   (return an error and exit immediately). Default: `error`.
@@ -206,6 +206,7 @@ Generate a project in ~/output from the templates in ~/templates, using variable
 
 ```
 boilerplate --template-url ~/templates --output-folder ~/output --var-file vars.yml
+boilerplate --template-url ~/templates --output-folder ~/output --var-file vars.json
 ```
 
 Generate a project in ~/output from the templates in this repo's `include` example dir, using variables read from a file:
@@ -416,11 +417,12 @@ five ways to provide a value for a variable:
    `--var foo='{key: "value"}' --var bar='["a", "b", "c"]'`. If you want to specify the value of a
    variable for a specific dependency, use the `<DEPENDENCY_NAME>.<VARIABLE_NAME>` syntax. For example:
    `boilerplate --var Description='Welcome to my home page!' --var about.Description='About Us' --var ShowLogo=false`.
-1. `--var-file` option(s) you pass in when calling boilerplate. Example: `boilerplate --var-file vars.yml`. The vars
-   file must be a simple YAML file that defines key, value pairs, where the key is the name of a variable (or
+1. `--var-file` option(s) you pass in when calling boilerplate. Example: `boilerplate --var-file vars.yml` or `boilerplate --var-file vars.json`. The vars
+   file can be either YAML or JSON format that defines key, value pairs, where the key is the name of a variable (or
    `<DEPENDENCY_NAME>.<VARIABLE_NAME>` for a variable in a dependency) and the value is the value to set for that
-   variable. Example:
+   variable. Examples:
 
+   YAML format:
    ```yaml
    Title: Boilerplate
    ShowLogo: false
@@ -432,6 +434,24 @@ five ways to provide a value for a variable:
    ExampleOfAList:
      - value1
      - value2
+   ```
+   
+   JSON format:
+   ```json
+   {
+     "Title": "Boilerplate",
+     "ShowLogo": false,
+     "Description": "Welcome to my home page!",
+     "about.Description": "Welcome to my home page!",
+     "ExampleOfAMap": {
+       "key1": "value1",
+       "key2": "value2"
+     },
+     "ExampleOfAList": [
+       "value1",
+       "value2"
+     ]
+   }
    ```
 1. Manual input. If no value is specified via the `--var` or `--var-file` flags, Boilerplate will interactively prompt
    the user to provide a value. Note that the `--non-interactive` flag disables this functionality.

--- a/cli/boilerplate_cli.go
+++ b/cli/boilerplate_cli.go
@@ -27,6 +27,7 @@ Generate a project in ~/output from the templates in ~/templates, using variable
 Generate a project in ~/output from the templates in ~/templates, using variables read from a file:
 
     boilerplate --template-url ~/templates --output-folder ~/output --var-file vars.yml
+    boilerplate --template-url ~/templates --output-folder ~/output --var-file vars.json
 
 Generate a project in ~/output from the templates in this repo's include example dir, using variables read from a file:
 
@@ -74,7 +75,7 @@ func CreateBoilerplateCli() *cli.App {
 		},
 		&cli.StringSliceFlag{
 			Name:  options.OptVarFile,
-			Usage: "Load variable values from the YAML file `FILE`. May be specified more than once.",
+			Usage: "Load variable values from the YAML or JSON file `FILE`. May be specified more than once.",
 		},
 		&cli.StringFlag{
 			Name:  options.OptMissingKeyAction,

--- a/integration-tests/json_varfile_test.go
+++ b/integration-tests/json_varfile_test.go
@@ -1,0 +1,82 @@
+package integration_tests
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/gruntwork-io/boilerplate/cli"
+	"github.com/gruntwork-io/boilerplate/errors"
+)
+
+// Test JSON variable file support specifically
+func TestJsonVarFileSupport(t *testing.T) {
+	t.Parallel()
+
+	// Create temporary directories for template and output
+	templateFolder, err := os.MkdirTemp("", "boilerplate-json-template")
+	require.NoError(t, err)
+	defer os.RemoveAll(templateFolder)
+
+	outputFolder, err := os.MkdirTemp("", "boilerplate-json-output")
+	require.NoError(t, err)
+	defer os.RemoveAll(outputFolder)
+
+	// Create a simple boilerplate.yml
+	boilerplateConfig := `variables:
+  - name: Name
+    type: string
+  - name: Active
+    type: bool`
+
+	err = os.WriteFile(filepath.Join(templateFolder, "boilerplate.yml"), []byte(boilerplateConfig), 0644)
+	require.NoError(t, err)
+
+	// Create a simple template file
+	templateContent := `Hello {{ .Name }}!
+Your active status is: {{ .Active }}.`
+	
+	err = os.WriteFile(filepath.Join(templateFolder, "greeting.txt"), []byte(templateContent), 0644)
+	require.NoError(t, err)
+
+	// Create JSON variable file
+	jsonVars := `{
+  "Name": "John Doe",
+  "Active": true
+}`
+
+	varFile := filepath.Join(templateFolder, "vars.json")
+	err = os.WriteFile(varFile, []byte(jsonVars), 0644)
+	require.NoError(t, err)
+
+	// Run boilerplate with JSON variable file
+	app := cli.CreateBoilerplateCli()
+	args := []string{
+		"boilerplate",
+		"--template-url",
+		templateFolder,
+		"--output-folder",
+		outputFolder,
+		"--var-file",
+		varFile,
+		"--non-interactive",
+		"--missing-key-action",
+		"error",
+	}
+
+	err = app.Run(args)
+	require.NoError(t, err, errors.PrintErrorWithStackTrace(err))
+
+	// Verify the output
+	outputFile := filepath.Join(outputFolder, "greeting.txt")
+	content, err := os.ReadFile(outputFile)
+	require.NoError(t, err)
+
+	expectedContent := `Hello John Doe!
+Your active status is: true.`
+
+	assert.Equal(t, expectedContent, string(content))
+}

--- a/test-fixtures/examples-expected-output/json/example1.json
+++ b/test-fixtures/examples-expected-output/json/example1.json
@@ -1,3 +1,3 @@
 {
-  "foo": "Hello"
+  "foo": "Hello from JSON"
 }

--- a/test-fixtures/examples-expected-output/json/example2.json
+++ b/test-fixtures/examples-expected-output/json/example2.json
@@ -1,3 +1,3 @@
 {
-  "foo: "Hello"
+  "foo: "Hello from JSON"
 }

--- a/test-fixtures/examples-var-files/json/vars.json
+++ b/test-fixtures/examples-var-files/json/vars.json
@@ -1,0 +1,3 @@
+{
+  "Foo": "Hello from JSON"
+}

--- a/variables/yaml_helpers_test.go
+++ b/variables/yaml_helpers_test.go
@@ -21,6 +21,14 @@ key2: value2
 key3: value3
 `
 
+const JSON_FILE_ONE_VAR = `{"key": "value"}`
+
+const JSON_FILE_MULTIPLE_VARS = `{
+  "key1": "value1",
+  "key2": "value2", 
+  "key3": "value3"
+}`
+
 func TestParseVariablesFromVarFileContents(t *testing.T) {
 	t.Parallel()
 
@@ -48,6 +56,33 @@ func TestParseVariablesFromVarFileContents(t *testing.T) {
 		}
 	}
 }
+
+func TestParseVariablesFromJsonFileContents(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		fileContents        string
+		expectJsonError     bool
+		expectedVars        map[string]interface{}
+	}{
+		{"{}", false, map[string]interface{}{}},
+		{JSON_FILE_ONE_VAR, false, map[string]interface{}{"key": "value"}},
+		{JSON_FILE_MULTIPLE_VARS, false, map[string]interface{}{"key1": "value1", "key2": "value2", "key3": "value3"}},
+		{"invalid json", true, map[string]interface{}{}},
+	}
+
+	for _, testCase := range testCases {
+		actualVars, err := parseVariablesFromJsonFileContents([]byte(testCase.fileContents))
+		if testCase.expectJsonError {
+			assert.NotNil(t, err)
+		} else {
+			assert.Nil(t, err, "Got unexpected error: %v", err)
+			assert.Equal(t, testCase.expectedVars, actualVars)
+		}
+	}
+}
+
+
 
 func TestParseVariablesFromKeyValuePairs(t *testing.T) {
 	t.Parallel()


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Allow json files to be used as var files.

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [x] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Added JSON file support for --var-file option alongside existing YAML support.

### Migration Guide

N/A
