### PR TITLE
Fix int - str conversion.

### DIFF
--- a/variables/variables.go
+++ b/variables/variables.go
@@ -251,6 +251,15 @@ func ConvertType(value interface{}, variable Variable) (interface{}, error) {
 		if isString {
 			return asString, nil
 		}
+		if asInt, isInt := value.(int); isInt {
+			return strconv.Itoa(asInt), nil
+		}
+		if asFloat, isFloat := value.(float64); isFloat {
+			return strconv.FormatFloat(asFloat, 'f', -1, 64), nil
+		}
+		if asBool, isBool := value.(bool); isBool {
+			return strconv.FormatBool(asBool), nil
+		}
 	case Int:
 		if asInt, isInt := value.(int); isInt {
 			return asInt, nil

--- a/variables/variables_test.go
+++ b/variables/variables_test.go
@@ -32,6 +32,84 @@ func TestParseStringAsList(t *testing.T) {
 
 }
 
+func TestConvertType(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		testName      string
+		value         interface{}
+		variableType  BoilerplateType
+		expectedValue interface{}
+		expectError   bool
+	}{
+		// String type tests
+		{"string-to-string", "hello", String, "hello", false},
+		{"int-to-string", 42, String, "42", false},
+		{"float64-to-string", 3.14, String, "3.14", false},
+		{"float64-to-string-whole", 42.0, String, "42", false},
+		{"float64-to-string-negative", -15.7, String, "-15.7", false},
+		{"bool-to-string", true, String, "true", false},
+		{"bool-to-string-false", false, String, "false", false},
+
+		// Int type tests - existing functionality
+		{"int-to-int", 42, Int, 42, false},
+		{"string-to-int-valid", "123", Int, 123, false},
+		{"string-to-int-invalid", "not-a-number", Int, nil, true},
+		
+		// Float type tests
+		{"float64-to-float", 3.14, Float, 3.14, false},
+		{"string-to-float-valid", "3.14", Float, 3.14, false},
+		{"string-to-float-invalid", "not-a-float", Float, nil, true},
+
+		// Bool type tests
+		{"bool-to-bool-true", true, Bool, true, false},
+		{"bool-to-bool-false", false, Bool, false, false},
+		{"string-to-bool-true", "true", Bool, true, false},
+		{"string-to-bool-false", "false", Bool, false, false},
+		{"string-to-bool-invalid", "maybe", Bool, nil, true},
+
+		// Nil value test
+		{"nil-value", nil, Int, nil, false},
+		{"nil-value-string", nil, String, nil, false},
+
+		// Invalid type conversions - only test truly invalid conversions
+		{"list-to-string-invalid", []string{"a", "b"}, String, nil, true},
+		{"bool-to-int-invalid", true, Int, nil, true},
+		{"list-to-int-invalid", []string{"a", "b"}, Int, nil, true},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.testName, func(t *testing.T) {
+			var variable Variable
+			switch testCase.variableType {
+			case String:
+				variable = NewStringVariable("test-var")
+			case Int:
+				variable = NewIntVariable("test-var")
+			case Float:
+				variable = NewFloatVariable("test-var")
+			case Bool:
+				variable = NewBoolVariable("test-var")
+			case List:
+				variable = NewListVariable("test-var")
+			case Map:
+				variable = NewMapVariable("test-var")
+			default:
+				t.Fatalf("Unsupported variable type in test: %v", testCase.variableType)
+			}
+
+			actualValue, err := ConvertType(testCase.value, variable)
+
+			if testCase.expectError {
+				assert.NotNil(t, err, "Expected error for test case: %s", testCase.testName)
+			} else {
+				assert.Nil(t, err, "Got unexpected error for test case '%s': %v", testCase.testName, err)
+				assert.Equal(t, testCase.expectedValue, actualValue, "For test case '%s'", testCase.testName)
+			}
+		})
+	}
+}
+
 func TestParseStringAsMap(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

Fixes #137.

Address issues of variable conversion/validation when strings look like float or ints.

## Problem

Currently, the ConvertType function has asymmetric type conversion logic:
- Int/Float/Bool variables can accept both their native type AND strings (with conversion)
- String variables only accept values that are already strings - no conversion from other types

This causes issues when using command line variables like --var aws_account_id=1234353, where YAML parsing converts the numeric value to an int, but the string variable cannot accept it.

## Examples of Issues Fixed

```bash
./boilerplate --var aws_account_id=1234353 --template-url test --output-folder /tmp
ERRO[...] Value '1234353' is not a valid value for variable 'aws_account_id' with type 'string'.
```

```bash
./boilerplate --var version=1.2 --template-url test --output-folder /tmp
ERRO[...] Value '1.2' is not a valid value for variable 'version' with type 'string'.
```

```bash
./boilerplate --var boolstring=true --template-url test --output-folder /tmp
ERRO[...] Value 'true' is not a valid value for variable 'boolstring' with type 'string'.
```

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [x] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [x] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated variable type conversion to allow automatic conversion of non-string types to strings, making string variables consistent with other variable types.

### Migration Guide

N/A
