### PR TITLE
Fix nested map conversion in ConvertType

### DIFF
--- a/variables/yaml_helpers.go
+++ b/variables/yaml_helpers.go
@@ -565,6 +565,16 @@ func ConvertYAMLToStringMap(yamlMapOrList any) (interface{}, error) {
 			outputMap[strK] = res
 		}
 		return outputMap, nil
+	// catch cases where there is a map[any]interface{} nested in a map[string]any
+	case map[string]any:
+		for k, v := range mapOrList {
+			res, err := ConvertYAMLToStringMap(v)
+			if err != nil {
+				return nil, err
+			}
+			mapOrList[k] = res
+		}
+		return mapOrList, nil
 	case []any:
 		for index, value := range mapOrList {
 			res, err := ConvertYAMLToStringMap(value)

--- a/variables/yaml_helpers_test.go
+++ b/variables/yaml_helpers_test.go
@@ -130,6 +130,55 @@ func TestConvert(t *testing.T) {
 	}
 }
 
+func TestConvertNested(t *testing.T) {
+	t.Parallel()
+
+	testCases := []struct {
+		name  string
+		input interface{}
+	}{
+		{
+			name: "map nested in map",
+			input: map[string]interface{}{
+				"key1": map[interface{}]interface{}{
+					"nested": "value",
+				},
+			},
+		},
+		{
+			name: "map nested in list",
+			input: []interface{}{
+				map[interface{}]interface{}{
+					"nested": "value",
+				},
+			},
+		},
+	}
+
+	for _, testCase := range testCases {
+		t.Run(testCase.name, func(t *testing.T) {
+			result, err := ConvertYAMLToStringMap(testCase.input)
+			assert.NoError(t, err)
+			
+			// Check that conversion actually happened - MUST work, not optional
+			switch v := result.(type) {
+			case map[string]interface{}:
+				for _, value := range v {
+					nestedMap, ok := value.(map[string]interface{})
+					assert.True(t, ok, "Expected nested map[string]interface{}, got %T", value)
+					assert.Equal(t, "value", nestedMap["nested"])
+				}
+			case []interface{}:
+				for _, item := range v {
+					nestedMap, ok := item.(map[string]interface{})
+					assert.True(t, ok, "Expected nested map[string]interface{}, got %T", item)
+					assert.Equal(t, "value", nestedMap["nested"])
+				}
+			}
+		})
+	}
+}
+
 func TestParserulestring(t *testing.T) {
 	t.Parallel()
 


### PR DESCRIPTION
<!-- Prepend '[WIP]' to the title if this PR is still a work-in-progress. Remove it when it is ready for review! -->

## Description

When a `map[interface{}]interface{}` map is nested under a `map[string]interface{}`, it is not properly converted.

<!-- Description of the changes introduced by this PR. -->

## TODOs

Read the [Gruntwork contribution guidelines](https://gruntwork.notion.site/Gruntwork-Coding-Methodology-02fdcd6e4b004e818553684760bf691e).

- [ ] Update the docs.
- [ ] Run the relevant tests successfully, including pre-commit checks.
- [ ] Ensure any 3rd party code adheres with our [license policy](https://www.notion.so/gruntwork/Gruntwork-licenses-and-open-source-usage-policy-f7dece1f780341c7b69c1763f22b1378) or delete this line if its not applicable.
- [ ] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes (draft)

Updated ConvertType to properly handle converting nested maps.

### Migration Guide

<!-- Important: If you made any backward incompatible changes, then you must write a migration guide! -->
