### PR TITLE
fix: address gocritic hugeParam and rangeValCopy lint errors

### DIFF
--- a/cli/boilerplate_cli.go
+++ b/cli/boilerplate_cli.go
@@ -126,5 +126,5 @@ func runApp(cliContext *cli.Context) error {
 	// The root boilerplate.yml is not itself a dependency, so we pass an empty Dependency.
 	emptyDep := variables.Dependency{}
 
-	return templates.ProcessTemplateWithContext(ctx, opts, opts, emptyDep)
+	return templates.ProcessTemplateWithContext(ctx, opts, opts, &emptyDep)
 }

--- a/config/config.go
+++ b/config/config.go
@@ -128,8 +128,8 @@ func (config *BoilerplateConfig) MarshalYAML() (any, error) {
 		// polymorphic to that type. So we reconstruct the list using the right type before passing it in to the marshal
 		// function.
 		interfaceList := []any{}
-		for _, dep := range config.Dependencies {
-			interfaceList = append(interfaceList, dep)
+		for i := range config.Dependencies {
+			interfaceList = append(interfaceList, &config.Dependencies[i])
 		}
 
 		depsYml, err := util.MarshalListOfObjectsToYAML(interfaceList)

--- a/config/get_variables.go
+++ b/config/get_variables.go
@@ -25,7 +25,7 @@ const MaxReferenceDepth = 20
 // GetVariables gets a value for each of the variables specified in boilerplateConfig, other than those already in existingVariables.
 // The value for a variable can come from the user (if the non-interactive option isn't set), the default value in the
 // config, or a command line option.
-func GetVariables(opts *options.BoilerplateOptions, boilerplateConfig, rootBoilerplateConfig *BoilerplateConfig, thisDep variables.Dependency) (map[string]any, error) {
+func GetVariables(opts *options.BoilerplateOptions, boilerplateConfig, rootBoilerplateConfig *BoilerplateConfig, thisDep *variables.Dependency) (map[string]any, error) {
 	return GetVariablesWithContext(context.Background(), opts, boilerplateConfig, rootBoilerplateConfig, thisDep)
 }
 
@@ -34,7 +34,7 @@ func GetVariables(opts *options.BoilerplateOptions, boilerplateConfig, rootBoile
 //
 // The value for a variable can come from the user (if the non-interactive option isn't set), the default value in the
 // config, or a command line option.
-func GetVariablesWithContext(ctx context.Context, opts *options.BoilerplateOptions, boilerplateConfig, rootBoilerplateConfig *BoilerplateConfig, thisDep variables.Dependency) (map[string]any, error) {
+func GetVariablesWithContext(ctx context.Context, opts *options.BoilerplateOptions, boilerplateConfig, rootBoilerplateConfig *BoilerplateConfig, thisDep *variables.Dependency) (map[string]any, error) {
 	renderedVariables := map[string]any{}
 
 	// Add a variable for all variables contained in the root config file. This will allow Golang template users
@@ -44,8 +44,10 @@ func GetVariablesWithContext(ctx context.Context, opts *options.BoilerplateOptio
 
 	// Add a variable for all dependencies contained in the root config file. This will allow Golang template users
 	// to directly access these with an expression like "{{ .BoilerplateConfigDeps.foo.OutputFolder }}"
-	rootConfigDeps := map[string]variables.Dependency{}
-	for _, dep := range rootBoilerplateConfig.Dependencies {
+	rootConfigDeps := map[string]*variables.Dependency{}
+
+	for i := range rootBoilerplateConfig.Dependencies {
+		dep := &rootBoilerplateConfig.Dependencies[i]
 		rootConfigDeps[dep.Name] = dep
 	}
 

--- a/config/get_variables_test.go
+++ b/config/get_variables_test.go
@@ -152,12 +152,12 @@ func TestGetVariablesNoVariables(t *testing.T) {
 	opts := &options.BoilerplateOptions{NonInteractive: true}
 	boilerplateConfig := &BoilerplateConfig{}
 	rootBoilerplateConfig := &BoilerplateConfig{}
-	dependency := variables.Dependency{}
+	dependency := &variables.Dependency{}
 
 	actual, err := GetVariables(opts, boilerplateConfig, rootBoilerplateConfig, dependency)
 	expected := map[string]interface{}{
 		"BoilerplateConfigVars": map[string]variables.Variable{},
-		"BoilerplateConfigDeps": map[string]variables.Dependency{},
+		"BoilerplateConfigDeps": map[string]*variables.Dependency{},
 		"This": map[string]interface{}{
 			"Config":     boilerplateConfig,
 			"Options":    opts,
@@ -179,7 +179,7 @@ func TestGetVariablesNoMatchNonInteractive(t *testing.T) {
 		},
 	}
 	rootBoilerplateConfig := &BoilerplateConfig{}
-	dependency := variables.Dependency{}
+	dependency := &variables.Dependency{}
 
 	_, err := GetVariables(opts, boilerplateConfig, rootBoilerplateConfig, dependency)
 
@@ -206,13 +206,13 @@ func TestGetVariablesMatchFromVars(t *testing.T) {
 
 	rootBoilerplateConfig := &BoilerplateConfig{}
 
-	dependency := variables.Dependency{}
+	dependency := &variables.Dependency{}
 
 	actual, err := GetVariables(opts, boilerplateConfig, rootBoilerplateConfig, dependency)
 	expected := map[string]interface{}{
 		"foo":                   "bar",
 		"BoilerplateConfigVars": map[string]variables.Variable{},
-		"BoilerplateConfigDeps": map[string]variables.Dependency{},
+		"BoilerplateConfigDeps": map[string]*variables.Dependency{},
 		"This": map[string]interface{}{
 			"Config":     boilerplateConfig,
 			"Options":    opts,
@@ -246,7 +246,7 @@ func TestGetVariablesMatchFromVarsAndDefaults(t *testing.T) {
 
 	rootBoilerplateConfig := &BoilerplateConfig{}
 
-	dependency := variables.Dependency{}
+	dependency := &variables.Dependency{}
 
 	actual, err := GetVariables(opts, boilerplateConfig, rootBoilerplateConfig, dependency)
 	expected := map[string]interface{}{
@@ -254,7 +254,7 @@ func TestGetVariablesMatchFromVarsAndDefaults(t *testing.T) {
 		"key2":                  "value2",
 		"key3":                  "value3",
 		"BoilerplateConfigVars": map[string]variables.Variable{},
-		"BoilerplateConfigDeps": map[string]variables.Dependency{},
+		"BoilerplateConfigDeps": map[string]*variables.Dependency{},
 		"This": map[string]interface{}{
 			"Config":     boilerplateConfig,
 			"Options":    opts,

--- a/templates/template_processor.go
+++ b/templates/template_processor.go
@@ -31,12 +31,12 @@ const defaultDirPerm = 0o777
 // function will load any missing variables (either from command line options or by prompting the user), execute all the
 // dependent boilerplate templates, and then execute this template. Note that we pass in rootOptions so that template
 // dependencies can inspect properties of the root template.
-func ProcessTemplate(options, rootOpts *options.BoilerplateOptions, thisDep variables.Dependency) error {
+func ProcessTemplate(options, rootOpts *options.BoilerplateOptions, thisDep *variables.Dependency) error {
 	return ProcessTemplateWithContext(context.Background(), options, rootOpts, thisDep)
 }
 
 // ProcessTemplateWithContext is like ProcessTemplate but accepts a context for cancellation and timeouts.
-func ProcessTemplateWithContext(ctx context.Context, options, rootOpts *options.BoilerplateOptions, thisDep variables.Dependency) error {
+func ProcessTemplateWithContext(ctx context.Context, options, rootOpts *options.BoilerplateOptions, thisDep *variables.Dependency) error {
 	// If TemplateFolder is already set, use that directly as it is a local template. Otherwise, download to a temporary
 	// working directory.
 	if options.TemplateFolder == "" {
@@ -142,7 +142,9 @@ func processHooks(ctx context.Context, hooks []variables.Hook, opts *options.Boi
 	executeAll := opts.NonInteractive // Auto-confirm all if non-interactive
 	hookAnswers := make(map[string]bool)
 
-	for _, hook := range hooks {
+	for i := range hooks {
+		hook := &hooks[i]
+
 		skip, err := shouldSkipHook(ctx, hook, opts, vars)
 		if err != nil || skip {
 			if skip {
@@ -195,7 +197,7 @@ func processHooks(ctx context.Context, hooks []variables.Hook, opts *options.Boi
 }
 
 // renderHookDetails renders the hook details and returns a pre-rendered string representation
-func renderHookDetails(ctx context.Context, hook variables.Hook, opts *options.BoilerplateOptions, vars map[string]any) (string, error) {
+func renderHookDetails(ctx context.Context, hook *variables.Hook, opts *options.BoilerplateOptions, vars map[string]any) (string, error) {
 	base := config.BoilerplateConfigPath(opts.TemplateFolder)
 	render := func(s string) (string, error) {
 		return render.RenderTemplateFromStringWithContext(ctx, base, s, vars, opts)
@@ -325,7 +327,7 @@ func printHookDetails(hookDetails string) {
 }
 
 // processHook processes the given hook, which is a script that should be execute at the command-line
-func processHook(ctx context.Context, hook variables.Hook, opts *options.BoilerplateOptions, vars map[string]any) error {
+func processHook(ctx context.Context, hook *variables.Hook, opts *options.BoilerplateOptions, vars map[string]any) error {
 	cmd, hookRenderErr := render.RenderTemplateFromStringWithContext(ctx, config.BoilerplateConfigPath(opts.TemplateFolder), hook.Command, vars, opts)
 	if hookRenderErr != nil {
 		return hookRenderErr
@@ -379,7 +381,7 @@ func processHook(ctx context.Context, hook variables.Hook, opts *options.Boilerp
 }
 
 // Return true if the "skip" condition of this hook evaluates to true
-func shouldSkipHook(ctx context.Context, hook variables.Hook, opts *options.BoilerplateOptions, vars map[string]interface{}) (bool, error) {
+func shouldSkipHook(ctx context.Context, hook *variables.Hook, opts *options.BoilerplateOptions, vars map[string]interface{}) (bool, error) {
 	if hook.Skip == "" {
 		return false, nil
 	}
@@ -402,8 +404,8 @@ func processDependencies(
 	variablesInConfig map[string]variables.Variable,
 	variables map[string]any,
 ) error {
-	for _, dependency := range dependencies {
-		err := processDependency(ctx, dependency, opts, variablesInConfig, variables)
+	for i := range dependencies {
+		err := processDependency(ctx, &dependencies[i], opts, variablesInConfig, variables)
 		if err != nil {
 			return err
 		}
@@ -415,7 +417,7 @@ func processDependencies(
 // processDependency is like processDependency but accepts a context for cancellation and timeouts.
 func processDependency(
 	ctx context.Context,
-	dependency variables.Dependency,
+	dependency *variables.Dependency,
 	opts *options.BoilerplateOptions,
 	variablesInConfig map[string]variables.Variable,
 	originalVars map[string]any,
@@ -475,7 +477,7 @@ func processDependency(
 // the original passed in, except for the template folder, output folder, and command-line vars.
 func cloneOptionsForDependency(
 	ctx context.Context,
-	dependency variables.Dependency,
+	dependency *variables.Dependency,
 	originalOpts *options.BoilerplateOptions,
 	variablesInConfig map[string]variables.Variable,
 	variables map[string]any,
@@ -543,7 +545,7 @@ func cloneOptionsForDependency(
 func cloneVariablesForDependency(
 	ctx context.Context,
 	opts *options.BoilerplateOptions,
-	dependency variables.Dependency,
+	dependency *variables.Dependency,
 	variablesInConfig map[string]variables.Variable,
 	originalVariables map[string]any,
 	renderedVarFiles []string,
@@ -649,7 +651,7 @@ func cloneVariablesForDependency(
 // options.NonInteractive or options.DisableDependencyPrompt are set to true, this function always returns true.
 func shouldProcessDependency(
 	ctx context.Context,
-	dependency variables.Dependency,
+	dependency *variables.Dependency,
 	opts *options.BoilerplateOptions,
 	variables map[string]any,
 ) (bool, error) {
@@ -670,7 +672,7 @@ func shouldProcessDependency(
 }
 
 // Return true if the skip parameter of the given dependency evaluates to a "true" value
-func shouldSkipDependency(ctx context.Context, dependency variables.Dependency, opts *options.BoilerplateOptions, variables map[string]interface{}) (bool, error) {
+func shouldSkipDependency(ctx context.Context, dependency *variables.Dependency, opts *options.BoilerplateOptions, variables map[string]interface{}) (bool, error) {
 	if dependency.Skip == "" {
 		return false, nil
 	}

--- a/templates/template_processor_test.go
+++ b/templates/template_processor_test.go
@@ -51,31 +51,31 @@ func TestCloneOptionsForDependency(t *testing.T) {
 	t.Parallel()
 
 	testCases := []struct {
+		dependency   *variables.Dependency
 		variables    map[string]interface{}
 		opts         options.BoilerplateOptions
 		expectedOpts options.BoilerplateOptions
-		dependency   variables.Dependency
 	}{
 		{
-			dependency:   variables.Dependency{Name: "dep1", TemplateURL: "../dep1", OutputFolder: "../out1"},
+			dependency:   &variables.Dependency{Name: "dep1", TemplateURL: "../dep1", OutputFolder: "../out1"},
 			opts:         options.BoilerplateOptions{TemplateFolder: "/template/path/", OutputFolder: "/output/path/", NonInteractive: true, Vars: map[string]interface{}{}, OnMissingKey: options.ExitWithError},
 			variables:    map[string]interface{}{},
 			expectedOpts: options.BoilerplateOptions{TemplateURL: "../dep1", TemplateFolder: filepath.FromSlash("/template/dep1"), OutputFolder: filepath.FromSlash("/output/out1"), NonInteractive: true, Vars: map[string]interface{}{}, OnMissingKey: options.ExitWithError},
 		},
 		{
-			dependency:   variables.Dependency{Name: "dep1", TemplateURL: "../dep1", OutputFolder: "../out1"},
+			dependency:   &variables.Dependency{Name: "dep1", TemplateURL: "../dep1", OutputFolder: "../out1"},
 			opts:         options.BoilerplateOptions{TemplateFolder: "/template/path/", OutputFolder: "/output/path/", DisableDependencyPrompt: true, Vars: map[string]interface{}{}, OnMissingKey: options.ExitWithError},
 			variables:    map[string]interface{}{},
 			expectedOpts: options.BoilerplateOptions{TemplateURL: "../dep1", TemplateFolder: filepath.FromSlash("/template/dep1"), OutputFolder: filepath.FromSlash("/output/out1"), DisableDependencyPrompt: true, Vars: map[string]interface{}{}, OnMissingKey: options.ExitWithError},
 		},
 		{
-			dependency:   variables.Dependency{Name: "dep1", TemplateURL: "../dep1", OutputFolder: "../out1"},
+			dependency:   &variables.Dependency{Name: "dep1", TemplateURL: "../dep1", OutputFolder: "../out1"},
 			opts:         options.BoilerplateOptions{TemplateFolder: "/template/path/", OutputFolder: "/output/path/", NonInteractive: false, Vars: map[string]interface{}{"foo": "bar"}, OnMissingKey: options.Invalid},
 			variables:    map[string]interface{}{"baz": "blah"},
 			expectedOpts: options.BoilerplateOptions{TemplateURL: "../dep1", TemplateFolder: filepath.FromSlash("/template/dep1"), OutputFolder: filepath.FromSlash("/output/out1"), NonInteractive: false, Vars: map[string]interface{}{"foo": "bar", "baz": "blah"}, OnMissingKey: options.Invalid},
 		},
 		{
-			dependency:   variables.Dependency{Name: "dep1", TemplateURL: "{{ .foo }}", OutputFolder: "{{ .baz }}"},
+			dependency:   &variables.Dependency{Name: "dep1", TemplateURL: "{{ .foo }}", OutputFolder: "{{ .baz }}"},
 			opts:         options.BoilerplateOptions{TemplateFolder: "/template/path/", OutputFolder: "/output/path/", NonInteractive: false, Vars: map[string]interface{}{}, OnMissingKey: options.ExitWithError},
 			variables:    map[string]interface{}{"foo": "bar", "baz": "blah"},
 			expectedOpts: options.BoilerplateOptions{TemplateURL: "bar", TemplateFolder: filepath.FromSlash("/template/path/bar"), OutputFolder: filepath.FromSlash("/output/path/blah"), NonInteractive: false, Vars: map[string]interface{}{"foo": "bar", "baz": "blah"}, OnMissingKey: options.ExitWithError},
@@ -101,34 +101,34 @@ func TestCloneVariablesForDependency(t *testing.T) {
 		variables         map[string]interface{}
 		optsVars          map[string]interface{}
 		expectedVariables map[string]interface{}
-		dependency        variables.Dependency
+		dependency        *variables.Dependency
 	}{
 		{
-			dependency:        variables.Dependency{Name: "dep1", TemplateURL: "../dep1", OutputFolder: "../out1"},
+			dependency:        &variables.Dependency{Name: "dep1", TemplateURL: "../dep1", OutputFolder: "../out1"},
 			variables:         map[string]interface{}{},
 			optsVars:          map[string]interface{}{},
 			expectedVariables: map[string]interface{}{},
 		},
 		{
-			dependency:        variables.Dependency{Name: "dep1", TemplateURL: "../dep1", OutputFolder: "../out1"},
+			dependency:        &variables.Dependency{Name: "dep1", TemplateURL: "../dep1", OutputFolder: "../out1"},
 			variables:         map[string]interface{}{"foo": "bar", "baz": "blah"},
 			optsVars:          map[string]interface{}{},
 			expectedVariables: map[string]interface{}{"foo": "bar", "baz": "blah"},
 		},
 		{
-			dependency:        variables.Dependency{Name: "dep1", TemplateURL: "../dep1", OutputFolder: "../out1"},
+			dependency:        &variables.Dependency{Name: "dep1", TemplateURL: "../dep1", OutputFolder: "../out1"},
 			variables:         map[string]interface{}{"foo": "bar", "baz": "blah"},
 			optsVars:          map[string]interface{}{"dep1.abc": "should-modify-name", "dep2.def": "should-copy-unmodified"},
 			expectedVariables: map[string]interface{}{"foo": "bar", "baz": "blah", "abc": "should-modify-name", "dep2.def": "should-copy-unmodified"},
 		},
 		{
-			dependency:        variables.Dependency{Name: "dep1", TemplateURL: "../dep1", OutputFolder: "../out1"},
+			dependency:        &variables.Dependency{Name: "dep1", TemplateURL: "../dep1", OutputFolder: "../out1"},
 			variables:         map[string]interface{}{"foo": "bar", "baz": "blah"},
 			optsVars:          map[string]interface{}{"dep1.abc": "should-modify-name", "dep2.def": "should-copy-unmodified", "abc": "should-be-overwritten-by-dep1.abc"},
 			expectedVariables: map[string]interface{}{"foo": "bar", "baz": "blah", "abc": "should-modify-name", "dep2.def": "should-copy-unmodified"},
 		},
 		{
-			dependency:        variables.Dependency{Name: "dep1", TemplateURL: "../dep1", OutputFolder: "../out1", DontInheritVariables: true},
+			dependency:        &variables.Dependency{Name: "dep1", TemplateURL: "../dep1", OutputFolder: "../out1", DontInheritVariables: true},
 			variables:         map[string]interface{}{"foo": "bar", "baz": "blah"},
 			optsVars:          map[string]interface{}{"dep1.abc": "should-modify-name", "dep2.def": "should-copy-unmodified"},
 			expectedVariables: map[string]interface{}{},
@@ -163,7 +163,7 @@ func TestForEachReferenceRendersAsTemplate(t *testing.T) {
 	err = os.WriteFile(filepath.Join(templateFolder, "test.txt"), []byte("{{ .__each__ }}"), 0o644)
 	require.NoError(t, err)
 
-	dependency := variables.Dependency{
+	dependency := &variables.Dependency{
 		Name:         "test",
 		TemplateURL:  ".",
 		OutputFolder: "{{ .__each__ }}",
@@ -172,7 +172,7 @@ func TestForEachReferenceRendersAsTemplate(t *testing.T) {
 	}
 
 	// Test data: region_1 points to template1, which contains the list to iterate over
-	variables := map[string]interface{}{
+	vars := map[string]interface{}{
 		"region": "region_1",
 		"deployments": map[string]interface{}{
 			"region_1": map[string]interface{}{
@@ -184,7 +184,7 @@ func TestForEachReferenceRendersAsTemplate(t *testing.T) {
 
 	opts := testutil.CreateTestOptionsWithOutput(templateFolder, tempDir)
 
-	err = processDependency(t.Context(), dependency, opts, nil, variables)
+	err = processDependency(t.Context(), dependency, opts, nil, vars)
 	require.NoError(t, err)
 
 	// Should create directories "a" and "b" from template1 list

--- a/variables/dependencies.go
+++ b/variables/dependencies.go
@@ -25,13 +25,13 @@ type Dependency struct {
 // TemplateUrl provides backward compatibility for accessing TemplateURL with lowercase "url"
 //
 //nolint:staticcheck
-func (d Dependency) TemplateUrl() string {
+func (d *Dependency) TemplateUrl() string {
 	return d.TemplateURL
 }
 
 // MarshalYAML implements the go-yaml marshaler interface so that the config can be marshaled into yaml. We use a custom marshaler
 // instead of defining the fields as tags so that we skip the attributes that are empty.
-func (d Dependency) MarshalYAML() (any, error) {
+func (d *Dependency) MarshalYAML() (any, error) {
 	depYml := map[string]any{}
 	if d.Name != "" {
 		depYml["name"] = d.Name

--- a/variables/hooks.go
+++ b/variables/hooks.go
@@ -21,7 +21,7 @@ type Hooks struct {
 
 // MarshalYAML implements the go-yaml marshaler interface so that the config can be marshaled into yaml. We use a custom marshaler
 // instead of defining the fields as tags so that we skip the attributes that are empty.
-func (hook Hook) MarshalYAML() (any, error) {
+func (hook *Hook) MarshalYAML() (any, error) {
 	hookYml := map[string]any{}
 	if hook.Command != "" {
 		hookYml["command"] = hook.Command
@@ -52,8 +52,8 @@ func (hooks Hooks) MarshalYAML() (any, error) {
 	// function.
 	if len(hooks.BeforeHooks) > 0 {
 		interfaceList := []interface{}{}
-		for _, hook := range hooks.BeforeHooks {
-			interfaceList = append(interfaceList, hook)
+		for i := range hooks.BeforeHooks {
+			interfaceList = append(interfaceList, &hooks.BeforeHooks[i])
 		}
 
 		beforeYml, err := util.MarshalListOfObjectsToYAML(interfaceList)
@@ -66,8 +66,8 @@ func (hooks Hooks) MarshalYAML() (any, error) {
 
 	if len(hooks.AfterHooks) > 0 {
 		interfaceList := []interface{}{}
-		for _, hook := range hooks.AfterHooks {
-			interfaceList = append(interfaceList, hook)
+		for i := range hooks.AfterHooks {
+			interfaceList = append(interfaceList, &hooks.AfterHooks[i])
 		}
 
 		afterYml, err := util.MarshalListOfObjectsToYAML(interfaceList)

--- a/variables/variables.go
+++ b/variables/variables.go
@@ -74,7 +74,7 @@ type defaultVariable struct {
 
 // NewStringVariable creates a new variable that holds a string
 func NewStringVariable(name string) Variable {
-	return defaultVariable{
+	return &defaultVariable{
 		name:         name,
 		variableType: String,
 	}
@@ -82,7 +82,7 @@ func NewStringVariable(name string) Variable {
 
 // NewIntVariable creates a new variable that holds an int
 func NewIntVariable(name string) Variable {
-	return defaultVariable{
+	return &defaultVariable{
 		name:         name,
 		variableType: Int,
 	}
@@ -90,7 +90,7 @@ func NewIntVariable(name string) Variable {
 
 // NewFloatVariable creates a new variable that holds a float
 func NewFloatVariable(name string) Variable {
-	return defaultVariable{
+	return &defaultVariable{
 		name:         name,
 		variableType: Float,
 	}
@@ -98,7 +98,7 @@ func NewFloatVariable(name string) Variable {
 
 // NewBoolVariable creates a new variable that holds a bool
 func NewBoolVariable(name string) Variable {
-	return defaultVariable{
+	return &defaultVariable{
 		name:         name,
 		variableType: Bool,
 	}
@@ -106,7 +106,7 @@ func NewBoolVariable(name string) Variable {
 
 // NewListVariable creates a new variable that holds a list of strings
 func NewListVariable(name string) Variable {
-	return defaultVariable{
+	return &defaultVariable{
 		name:         name,
 		variableType: List,
 	}
@@ -114,7 +114,7 @@ func NewListVariable(name string) Variable {
 
 // NewMapVariable creates a new variable that holds a map of string to string
 func NewMapVariable(name string) Variable {
-	return defaultVariable{
+	return &defaultVariable{
 		name:         name,
 		variableType: Map,
 	}
@@ -122,18 +122,18 @@ func NewMapVariable(name string) Variable {
 
 // NewEnumVariable creates a new variable that holds an enum with the given possible values
 func NewEnumVariable(name string, options []string) Variable {
-	return defaultVariable{
+	return &defaultVariable{
 		name:         name,
 		variableType: Enum,
 		options:      options,
 	}
 }
 
-func (variable defaultVariable) Name() string {
+func (variable *defaultVariable) Name() string {
 	return variable.name
 }
 
-func (variable defaultVariable) FullName() string {
+func (variable *defaultVariable) FullName() string {
 	dependencyName, variableName := SplitIntoDependencyNameAndVariableName(variable.Name())
 	if dependencyName == "" {
 		return variableName
@@ -142,54 +142,54 @@ func (variable defaultVariable) FullName() string {
 	}
 }
 
-func (variable defaultVariable) Description() string {
+func (variable *defaultVariable) Description() string {
 	return variable.description
 }
 
-func (variable defaultVariable) Type() BoilerplateType {
+func (variable *defaultVariable) Type() BoilerplateType {
 	return variable.variableType
 }
 
-func (variable defaultVariable) Order() int {
+func (variable *defaultVariable) Order() int {
 	return variable.order
 }
 
-func (variable defaultVariable) Default() any {
+func (variable *defaultVariable) Default() any {
 	return variable.defaultValue
 }
 
-func (variable defaultVariable) Reference() string {
+func (variable *defaultVariable) Reference() string {
 	return variable.reference
 }
 
-func (variable defaultVariable) Options() []string {
+func (variable *defaultVariable) Options() []string {
 	return variable.options
 }
 
-func (variable defaultVariable) Validations() []CustomValidationRule {
+func (variable *defaultVariable) Validations() []CustomValidationRule {
 	return variable.validations
 }
 
-func (variable defaultVariable) WithName(name string) Variable {
+func (variable *defaultVariable) WithName(name string) Variable {
 	variable.name = name
 	return variable
 }
 
-func (variable defaultVariable) WithDescription(description string) Variable {
+func (variable *defaultVariable) WithDescription(description string) Variable {
 	variable.description = description
 	return variable
 }
 
-func (variable defaultVariable) WithDefault(value any) Variable {
+func (variable *defaultVariable) WithDefault(value any) Variable {
 	variable.defaultValue = value
 	return variable
 }
 
-func (variable defaultVariable) String() string {
+func (variable *defaultVariable) String() string {
 	return fmt.Sprintf("Variable {Name: '%s', Description: '%s', Type: '%v', Default: '%v', Options: '%v', Reference: '%v'}", variable.Name(), variable.Description(), variable.Type(), variable.Default(), variable.Options(), variable.Reference())
 }
 
-func (variable defaultVariable) ExampleValue() string {
+func (variable *defaultVariable) ExampleValue() string {
 	switch variable.Type() {
 	case String:
 		return "foo"
@@ -211,7 +211,7 @@ func (variable defaultVariable) ExampleValue() string {
 }
 
 // Define a custom marshaler for YAML so that variables (and thus any struct using it) can be marshaled into YAML.
-func (variable defaultVariable) MarshalYAML() (any, error) {
+func (variable *defaultVariable) MarshalYAML() (any, error) {
 	varYml := map[string]any{}
 	// We avoid a straight assignment to ensure that only fields that are actually set are rendered out.
 	if variable.Name() != "" {
@@ -344,7 +344,7 @@ func parseStringAsList(str string) ([]string, error) {
 		return goOut, nil
 	}
 
-	return nil, errors.WithStackTrace(FormatNotJSONOrGo{
+	return nil, errors.WithStackTrace(&FormatNotJSONOrGo{
 		ExpectedJSONFormat: `["value1", "value2", "value3"]`,
 		ExpectedGoFormat:   `[value1 value2 value3]`,
 		ActualFormat:       str,
@@ -400,7 +400,7 @@ func parseStringAsMap(str string) (map[string]string, error) {
 		return goOut, nil
 	}
 
-	return nil, errors.WithStackTrace(FormatNotJSONOrGo{
+	return nil, errors.WithStackTrace(&FormatNotJSONOrGo{
 		ExpectedJSONFormat: `{"key1": "value1", "key2": "value2", "key3": "value3"}`,
 		ExpectedGoFormat:   `map[key1:value1 key2:value2 key3:value3]`,
 		ActualFormat:       str,
@@ -562,7 +562,7 @@ func UnmarshalVariableFromBoilerplateConfigYaml(fields map[string]interface{}) (
 
 	variable.defaultValue = fields["default"]
 
-	return variable, nil
+	return &variable, nil
 }
 
 // Custom error types
@@ -585,6 +585,6 @@ type FormatNotJSONOrGo struct {
 	ActualFormat       string
 }
 
-func (err FormatNotJSONOrGo) Error() string {
+func (err *FormatNotJSONOrGo) Error() string {
 	return fmt.Sprintf("Expected a string in JSON format (e.g., %s) or Go format (e.g., %s), but got: %s. JSON parsing error: %v. Go parsing error: %v.", err.ExpectedJSONFormat, err.ExpectedGoFormat, err.ActualFormat, err.JSONErr, err.GoErr)
 }


### PR DESCRIPTION
## Summary
- Updates method receivers and function parameters to use pointers for large structs (`Dependency`, `Hook`, `defaultVariable`)
- Converts range loops to use index-based access to avoid copying large structs
- Fixes lint failures caused by upstream terragrunt `.golangci.yml` enabling stricter `gocritic` checks

## Test plan
- [x] `make lint` passes with 0 issues
- [x] All unit tests pass (`go test ./config/... ./templates/... ./variables/...`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)