### PR TITLE
chore: use committed lint config with weekly upstream sync

### DIFF
--- a/.github/workflows/update-lint-config.yml
+++ b/.github/workflows/update-lint-config.yml
@@ -1,0 +1,42 @@
+name: Update Lint Config
+
+on:
+  schedule:
+    # Run every Monday at 00:00 UTC
+    - cron: '0 0 * * 1'
+  workflow_dispatch:
+
+jobs:
+  update-lint-config:
+    runs-on: ubuntu-latest
+
+    steps:
+    - uses: actions/checkout@v5
+
+    - name: Update lint config from upstream
+      run: make update-lint-config
+
+    - name: Check for changes
+      id: check
+      run: |
+        if git diff --quiet .golangci.yml; then
+          echo "changed=false" >> "$GITHUB_OUTPUT"
+        else
+          echo "changed=true" >> "$GITHUB_OUTPUT"
+        fi
+
+    - name: Create Pull Request
+      if: steps.check.outputs.changed == 'true'
+      uses: peter-evans/create-pull-request@v7
+      with:
+        token: ${{ secrets.GITHUB_TOKEN }}
+        commit-message: "chore: update golangci-lint config from upstream"
+        title: "chore: update golangci-lint config from upstream"
+        body: |
+          This PR updates the golangci-lint configuration from the upstream Terragrunt repository.
+
+          Source: https://github.com/gruntwork-io/terragrunt/blob/main/.golangci.yml
+
+          This is an automated PR created by the update-lint-config workflow.
+        branch: update-lint-config
+        delete-branch: true

--- a/Makefile
+++ b/Makefile
@@ -10,15 +10,16 @@ build: $(shell find . \( -type f -name '*.go' -print \))
 clean:
 	rm -f boilerplate
 
-lint: SHELL:=/bin/bash
 lint:
-	golangci-lint run -c <(curl -s https://raw.githubusercontent.com/gruntwork-io/terragrunt/main/.golangci.yml) ./...
+	golangci-lint run ./...
 
-update-local-lint: SHELL:=/bin/bash
-update-local-lint:
+update-lint-config: SHELL:=/bin/bash
+update-lint-config:
 	curl -s https://raw.githubusercontent.com/gruntwork-io/terragrunt/main/.golangci.yml --output .golangci.yml
 	tmpfile=$$(mktemp) ;\
-	echo '# This file is generated using `make update-local-lint` to track the linting used in Terragrunt. Do not edit manually.' | cat - .golangci.yml > $${tmpfile} && mv $${tmpfile} .golangci.yml
+	{ echo '# This file is generated from https://github.com/gruntwork-io/terragrunt/blob/main/.golangci.yml' ;\
+	  echo '# It is automatically updated weekly via the update-lint-config workflow. Do not edit manually.' ;\
+	  cat .golangci.yml; } > $${tmpfile} && mv $${tmpfile} .golangci.yml
 
 test:
 	go test -v ./...
@@ -27,4 +28,4 @@ fmt:
 	@echo "Running source files through gofmt..."
 	gofmt -w $(GOFMT_FILES)
 
-.PHONY: lint test default
+.PHONY: lint test default update-lint-config


### PR DESCRIPTION
## Summary
- Change `make lint` to use the local `.golangci.yml` instead of downloading it on-the-fly from Terragrunt, which was fragile and could break over time
- Rename `update-local-lint` to `update-lint-config`
- Add GitHub workflow that runs weekly (Mondays at 00:00 UTC) to check for upstream changes and creates a PR if the config has changed

## Test plan
- [ ] Verify `make lint` works with the local config
- [ ] Verify `make update-lint-config` downloads and updates the file correctly
- [ ] Manually trigger the workflow via `workflow_dispatch` to test PR creation

🤖 Generated with [Claude Code](https://claude.com/claude-code)