### PR TITLE
Fix flaky TestExamplesShell by isolating parallel sub-test output directories

### DIFF
--- a/integration-tests/examples_unix_test.go
+++ b/integration-tests/examples_unix_test.go
@@ -44,7 +44,10 @@ func TestExamplesShell(t *testing.T) {
 					t.Run(fmt.Sprintf("%s-missing-key-%s", example, string(missingKeyAction)), func(t *testing.T) {
 						t.Parallel()
 
-						testExample(t, templateFolder, outputFolder, varFile, expectedOutputFolder, string(missingKeyAction))
+						// Each sub-test needs its own output folder to avoid races when
+						// parallel sub-tests write hook output files to the same directory.
+						actionOutputFolder := path.Join(outputFolder, string(missingKeyAction))
+						testExample(t, templateFolder, actionOutputFolder, varFile, expectedOutputFolder, string(missingKeyAction))
 					})
 				}
 			})


### PR DESCRIPTION
- The `TestExamplesShell` integration test was intermittently failing (most commonly `shell-missing-key-invalid`) because the three `missingKeyAction` sub-tests (`invalid`, `zero`, `error`) run in parallel but all wrote to the same output directory.
- Shell hooks (e.g., `before-hook-example.txt`, `after-hook-example.txt`) from concurrent sub-tests would race over the shared output folder, causing diff assertions to see stale or partially-written files.
- Fixed by giving each sub-test its own output folder (appending the `missingKeyAction` to the path), so parallel runs are fully isolated.

## TODOs

- [X] Update the docs. (N/A)
- [X] Run the relevant tests successfully, including pre-commit checks.
- [X] Include release notes. If this PR is backward incompatible, include a migration guide.

## Release Notes

- Fixed flaky tests by giving them each their own output folder