### PR TITLE
switch logging to slog

### DIFF
--- a/cli/boilerplate_cli.go
+++ b/cli/boilerplate_cli.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"fmt"
+	"io"
+	"log/slog"
 
 	"github.com/gruntwork-io/go-commons/entrypoint"
 	"github.com/gruntwork-io/go-commons/version"
@@ -9,6 +11,7 @@ import (
 
 	"github.com/gruntwork-io/boilerplate/options"
 	"github.com/gruntwork-io/boilerplate/templates"
+	"github.com/gruntwork-io/boilerplate/util/prefixer"
 	"github.com/gruntwork-io/boilerplate/variables"
 )
 
@@ -96,6 +99,10 @@ func CreateBoilerplateCli() *cli.App {
 			Name:  options.OptDisableDependencyPrompt,
 			Usage: fmt.Sprintf("Do not prompt for confirmation to include dependencies. Has the same effect as --%s, without disabling variable prompts.", options.OptNonInteractive),
 		},
+		&cli.BoolFlag{
+			Name:  options.OptSilent,
+			Usage: "Do not output any log messages",
+		},
 	}
 
 	// We pass JSON/YAML content to various CLI flags, such as --var, and this JSON/YAML content may contain commas or
@@ -118,6 +125,13 @@ func runApp(cliContext *cli.Context) error {
 	opts, err := options.ParseOptions(cliContext)
 	if err != nil {
 		return err
+	}
+
+	// Set up the default logger based on the --silent flag
+	if opts.Silent {
+		slog.SetDefault(slog.New(slog.NewTextHandler(io.Discard, nil)))
+	} else {
+		slog.SetDefault(slog.New(prefixer.New()))
 	}
 
 	// The root boilerplate.yml is not itself a dependency, so we pass an empty Dependency.

--- a/config/config.go
+++ b/config/config.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"io/ioutil"
+	"log/slog"
 	"net/url"
 	"path"
 	"strings"
@@ -41,10 +42,10 @@ func (config *BoilerplateConfig) GetVariablesMap() map[string]variables.Variable
 
 // Implement the go-yaml unmarshal interface for BoilerplateConfig. We can't let go-yaml handle this itself because:
 //
-// 1. Variable is an interface
-// 2. We need to provide Defaults for optional fields, such as "type"
-// 3. We want to validate the variable as part of the unmarshalling process so we never have invalid Variable or
-//    Dependency classes floating around
+//  1. Variable is an interface
+//  2. We need to provide Defaults for optional fields, such as "type"
+//  3. We want to validate the variable as part of the unmarshalling process so we never have invalid Variable or
+//     Dependency classes floating around
 func (config *BoilerplateConfig) UnmarshalYAML(unmarshal func(interface{}) error) error {
 	var fields map[string]interface{}
 	if err := unmarshal(&fields); err != nil {
@@ -176,7 +177,7 @@ func LoadBoilerplateConfig(opts *options.BoilerplateOptions) (*BoilerplateConfig
 	configPath := BoilerplateConfigPath(opts.TemplateFolder)
 
 	if util.PathExists(configPath) {
-		util.Logger.Printf("Loading boilerplate config from %s", configPath)
+		slog.Default().Info(fmt.Sprintf("Loading boilerplate config from %s", configPath))
 		bytes, err := ioutil.ReadFile(configPath)
 		if err != nil {
 			return nil, errors.WithStackTrace(err)
@@ -184,7 +185,7 @@ func LoadBoilerplateConfig(opts *options.BoilerplateOptions) (*BoilerplateConfig
 
 		return ParseBoilerplateConfig(bytes)
 	} else if opts.OnMissingConfig == options.Ignore {
-		util.Logger.Printf("Warning: boilerplate config file not found at %s. The %s flag is set, so ignoring. Note that no variables will be available while generating.", configPath, options.OptMissingConfigAction)
+		slog.Default().Info(fmt.Sprintf("Warning: boilerplate config file not found at %s. The %s flag is set, so ignoring. Note that no variables will be available while generating.", configPath, options.OptMissingConfigAction))
 		return &BoilerplateConfig{}, nil
 	} else {
 		// If the template URL is similar to a git URL, surface in error message that there may be a misspelling/typo.

--- a/config/get_variables.go
+++ b/config/get_variables.go
@@ -3,6 +3,7 @@ package config
 import (
 	"fmt"
 	"log"
+	"log/slog"
 	"sort"
 	"strconv"
 
@@ -170,10 +171,10 @@ func getVariable(variable variables.Variable, opts *options.BoilerplateOptions) 
 	valueFromVars, valueSpecifiedInVars := getVariableFromVars(variable, opts)
 
 	if valueSpecifiedInVars {
-		util.Logger.Printf("Using value specified via command line options for variable '%s': %s", variable.FullName(), valueFromVars)
+		slog.Default().Info(fmt.Sprintf("Using value specified via command line options for variable '%s': %s", variable.FullName(), valueFromVars))
 		return valueFromVars, nil
 	} else if opts.NonInteractive && variable.Default() != nil {
-		util.Logger.Printf("Using default value for variable '%s': %v", variable.FullName(), variable.Default())
+		slog.Default().Info(fmt.Sprintf("Using default value for variable '%s': %v", variable.FullName(), variable.Default()))
 		return variable.Default(), nil
 	} else if opts.NonInteractive {
 		return nil, errors.WithStackTrace(MissingVariableWithNonInteractiveMode(variable.FullName()))
@@ -269,7 +270,7 @@ func getVariableFromUser(variable variables.Variable, opts *options.BoilerplateO
 
 	if value == "" {
 		// TODO: what if the user wanted an empty string instead of the default?
-		util.Logger.Printf("Using default value for variable '%s': %v", variable.FullName(), variable.Default())
+		slog.Default().Info(fmt.Sprintf("Using default value for variable '%s': %v", variable.FullName(), variable.Default()))
 		return variable.Default(), nil
 	}
 

--- a/getter-helper/getter_helper.go
+++ b/getter-helper/getter_helper.go
@@ -3,6 +3,7 @@ package getter_helper
 import (
 	"context"
 	"fmt"
+	"log/slog"
 	"net/url"
 	"os"
 	"path/filepath"
@@ -12,7 +13,6 @@ import (
 	urlhelper "github.com/hashicorp/go-getter/helper/url"
 
 	"github.com/gruntwork-io/boilerplate/errors"
-	"github.com/gruntwork-io/boilerplate/util"
 )
 
 var forcedRegexp = regexp.MustCompile(`^([A-Za-z0-9]+)::(.+)$`)
@@ -109,7 +109,7 @@ func DownloadTemplatesToTemporaryFolder(templateUrl string) (string, string, err
 	// Always set a subdir path because go-getter can not clone into an existing dir.
 	cloneDir := filepath.Join(workingDir, "wd")
 
-	util.Logger.Printf("Downloading templates from %s to %s", templateUrl, workingDir)
+	slog.Default().Info(fmt.Sprintf("Downloading templates from %s to %s", templateUrl, workingDir))
 
 	// If there is a subdir component, we download everything and combine the path at the end to return the working path
 	mainPath, subDir := getter.SourceDirSubdir(templateUrl)

--- a/integration-tests/error_message_test.go
+++ b/integration-tests/error_message_test.go
@@ -28,6 +28,7 @@ func TestMisspelledTemplateURLErrorMessage(t *testing.T) {
 		"--output-folder",
 		outputFolder,
 		"--non-interactive",
+		"--silent",
 	}
 	runErr := app.Run(args)
 	assert.Error(t, runErr, errors.PrintErrorWithStackTrace(runErr))

--- a/integration-tests/examples_test.go
+++ b/integration-tests/examples_test.go
@@ -137,6 +137,7 @@ func testExample(t *testing.T, templateFolder string, outputFolder string, varFi
 		"--non-interactive",
 		"--missing-key-action",
 		missingKeyAction,
+		"--silent",
 	}
 
 	// Special handling for the shell-disabled case, which we use to test that we can disable hooks and shell helpers

--- a/integration-tests/required_version_test.go
+++ b/integration-tests/required_version_test.go
@@ -69,6 +69,7 @@ func runRequiredVersionExample(t *testing.T, templateFolder string) error {
 		"--output-folder",
 		outputPath,
 		"--non-interactive",
+		"--silent",
 	}
 	return app.Run(args)
 }

--- a/integration-tests/slice_parsing_test.go
+++ b/integration-tests/slice_parsing_test.go
@@ -34,6 +34,7 @@ func TestSliceParsing(t *testing.T) {
 		"--var",
 		fmt.Sprintf("MapValue=%s", mapValue),
 		"--non-interactive",
+		"--silent",
 	}
 
 	runErr := app.Run(args)

--- a/options/options.go
+++ b/options/options.go
@@ -20,6 +20,7 @@ const OptMissingConfigAction = "missing-config-action"
 const OptDisableHooks = "disable-hooks"
 const OptDisableShell = "disable-shell"
 const OptDisableDependencyPrompt = "disable-dependency-prompt"
+const OptSilent = "silent"
 
 // The command-line options for the boilerplate app
 type BoilerplateOptions struct {
@@ -36,6 +37,7 @@ type BoilerplateOptions struct {
 	DisableHooks            bool
 	DisableShell            bool
 	DisableDependencyPrompt bool
+	Silent                  bool
 }
 
 // Validate that the options have reasonable values and return an error if they don't
@@ -96,6 +98,7 @@ func ParseOptions(cliContext *cli.Context) (*BoilerplateOptions, error) {
 		DisableHooks:            cliContext.Bool(OptDisableHooks),
 		DisableShell:            cliContext.Bool(OptDisableShell),
 		DisableDependencyPrompt: cliContext.Bool(OptDisableDependencyPrompt),
+		Silent:                  cliContext.Bool(OptSilent),
 	}
 
 	if err := options.Validate(); err != nil {

--- a/render/template_helpers.go
+++ b/render/template_helpers.go
@@ -4,6 +4,7 @@ import (
 	"bufio"
 	"fmt"
 	"io/ioutil"
+	"log/slog"
 	"math"
 	"os"
 	"path"
@@ -255,7 +256,7 @@ func include(templatePath string, opts *options.BoilerplateOptions, path string,
 // Example:
 //
 // pathRelativeToTemplate("/foo/bar/template-file.txt, "../src/code.java")
-//   Returns: "/foo/src/code.java"
+// Returns: "/foo/src/code.java"
 func PathRelativeToTemplate(templatePath string, filePath string) string {
 	if path.IsAbs(filePath) {
 		return filePath
@@ -606,7 +607,7 @@ func keys(value interface{}) ([]string, error) {
 // string.
 func shell(templatePath string, opts *options.BoilerplateOptions, rawArgs ...string) (string, error) {
 	if opts.DisableShell {
-		util.Logger.Printf("Shell helpers are disabled. Will not execute shell command '%v'. Returning placeholder value '%s' instead.", rawArgs, SHELL_DISABLED_PLACEHOLDER)
+		slog.Default().Info(fmt.Sprintf("Shell helpers are disabled. Will not execute shell command '%v'. Returning placeholder value '%s' instead.", rawArgs, SHELL_DISABLED_PLACEHOLDER))
 		return SHELL_DISABLED_PLACEHOLDER, nil
 	}
 

--- a/templates/skip_files_processor.go
+++ b/templates/skip_files_processor.go
@@ -1,6 +1,8 @@
 package templates
 
 import (
+	"fmt"
+	"log/slog"
 	"path/filepath"
 
 	zglob "github.com/mattn/go-zglob"
@@ -8,7 +10,6 @@ import (
 	"github.com/gruntwork-io/boilerplate/errors"
 	"github.com/gruntwork-io/boilerplate/options"
 	"github.com/gruntwork-io/boilerplate/render"
-	"github.com/gruntwork-io/boilerplate/util"
 	"github.com/gruntwork-io/boilerplate/variables"
 )
 
@@ -75,20 +76,20 @@ func skipFileIfCondition(skipFile variables.SkipFile, opts *options.BoilerplateO
 
 	// TODO: logger-debug - switch to debug
 	if skipFile.Path != "" {
-		util.Logger.Printf("If attribute for SkipFile Path %s evaluated to '%s'", skipFile.Path, rendered)
+		slog.Default().Info(fmt.Sprintf("If attribute for SkipFile Path %s evaluated to '%s'", skipFile.Path, rendered))
 	} else if skipFile.NotPath != "" {
-		util.Logger.Printf("If attribute for SkipFile NotPath %s evaluated to '%s'", skipFile.NotPath, rendered)
+		slog.Default().Info(fmt.Sprintf("If attribute for SkipFile NotPath %s evaluated to '%s'", skipFile.NotPath, rendered))
 	} else {
-		util.Logger.Printf("WARN: SkipFile has no path or not_path!")
+		slog.Default().Info(fmt.Sprintf("WARN: SkipFile has no path or not_path!"))
 	}
 	return rendered == "true", nil
 }
 
 func debugLogForMatchedPaths(sourcePath string, paths []string, directiveName string, directiveAttribute string) {
 	// TODO: logger-debug - switch to debug
-	util.Logger.Printf("Following paths were picked up by %s attribute for %s (%s):", directiveAttribute, directiveName, sourcePath)
+	slog.Default().Info(fmt.Sprintf("Following paths were picked up by %s attribute for %s (%s):", directiveAttribute, directiveName, sourcePath))
 	for _, path := range paths {
-		util.Logger.Printf("\t- %s", path)
+		slog.Default().Info(fmt.Sprintf("\t- %s", path))
 	}
 }
 
@@ -108,7 +109,7 @@ func renderGlobPath(opts *options.BoilerplateOptions, path string, variables map
 	rawMatchedPaths, err := zglob.Glob(globPath)
 	if err != nil {
 		// TODO: logger-debug - switch to debug
-		util.Logger.Printf("ERROR: could not glob %s", globPath)
+		slog.Default().Info(fmt.Sprintf("ERROR: could not glob %s", globPath))
 		return nil, errors.WithStackTrace(err)
 	}
 	// Canonicalize the matched paths prior to storage

--- a/templates/template_processor.go
+++ b/templates/template_processor.go
@@ -2,6 +2,7 @@ package templates
 
 import (
 	"fmt"
+	"log/slog"
 	"net/url"
 	"os"
 	"path"
@@ -28,12 +29,21 @@ const eachVarName = "__each__"
 // dependent boilerplate templates, and then execute this template. Note that we pass in rootOptions so that template
 // dependencies can inspect properties of the root template.
 func ProcessTemplate(options, rootOpts *options.BoilerplateOptions, thisDep variables.Dependency) error {
+	return ProcessTemplateWithLogger(slog.Default(), options, rootOpts, thisDep)
+}
+
+// ProcessTemplateWithLogger allows passing a custom logger.
+// This is the internal implementation that does the actual work.
+func ProcessTemplateWithLogger(logger *slog.Logger, options, rootOpts *options.BoilerplateOptions, thisDep variables.Dependency) error {
+	// Set the provided logger as the default for this execution
+	slog.SetDefault(logger)
+
 	// If TemplateFolder is already set, use that directly as it is a local template. Otherwise, download to a temporary
 	// working directory.
 	if options.TemplateFolder == "" {
 		workingDir, templateFolder, err := getter_helper.DownloadTemplatesToTemporaryFolder(options.TemplateUrl)
 		defer func() {
-			util.Logger.Printf("Cleaning up working directory.")
+			slog.Default().Info(fmt.Sprintf("Cleaning up working directory."))
 			os.RemoveAll(workingDir)
 		}()
 		if err != nil {
@@ -129,7 +139,7 @@ func processHook(hook variables.Hook, opts *options.BoilerplateOptions, vars map
 		return err
 	}
 	if skip {
-		util.Logger.Printf("Skipping hook with command '%s'", hook.Command)
+		slog.Default().Info(fmt.Sprintf("Skipping hook with command '%s'", hook.Command))
 		return nil
 	}
 
@@ -176,7 +186,7 @@ func processHook(hook variables.Hook, opts *options.BoilerplateOptions, vars map
 // Return true if the "skip" condition of this hook evaluates to true
 func shouldSkipHook(hook variables.Hook, opts *options.BoilerplateOptions, vars map[string]interface{}) (bool, error) {
 	if opts.DisableHooks {
-		util.Logger.Printf("Hooks are disabled")
+		slog.Default().Info(fmt.Sprintf("Hooks are disabled"))
 		return true, nil
 	}
 
@@ -189,7 +199,7 @@ func shouldSkipHook(hook variables.Hook, opts *options.BoilerplateOptions, vars 
 		return false, err
 	}
 
-	util.Logger.Printf("Skip attribute for hook with command '%s' evaluated to '%s'", hook.Command, rendered)
+	slog.Default().Info(fmt.Sprintf("Skip attribute for hook with command '%s' evaluated to '%s'", hook.Command, rendered))
 	return rendered == "true", nil
 }
 
@@ -229,7 +239,7 @@ func processDependency(
 				return err
 			}
 
-			util.Logger.Printf("Processing dependency %s, with template folder %s and output folder %s", dependency.Name, dependencyOptions.TemplateFolder, dependencyOptions.OutputFolder)
+			slog.Default().Info(fmt.Sprintf("Processing dependency %s, with template folder %s and output folder %s", dependency.Name, dependencyOptions.TemplateFolder, dependencyOptions.OutputFolder))
 			return ProcessTemplate(dependencyOptions, opts, dependency)
 		}
 
@@ -256,7 +266,7 @@ func processDependency(
 			return doProcess(originalVars)
 		}
 	} else {
-		util.Logger.Printf("Skipping dependency %s", dependency.Name)
+		slog.Default().Info(fmt.Sprintf("Skipping dependency %s", dependency.Name))
 		return nil
 	}
 }
@@ -444,7 +454,7 @@ func shouldSkipDependency(dependency variables.Dependency, opts *options.Boilerp
 		return false, err
 	}
 
-	util.Logger.Printf("Skip attribute for dependency %s evaluated to '%s'", dependency.Name, rendered)
+	slog.Default().Info(fmt.Sprintf("Skip attribute for dependency %s evaluated to '%s'", dependency.Name, rendered))
 	return rendered == "true", nil
 }
 
@@ -456,7 +466,7 @@ func processTemplateFolder(
 	variables map[string]interface{},
 	partials []string,
 ) error {
-	util.Logger.Printf("Processing templates in %s and outputting generated files to %s", opts.TemplateFolder, opts.OutputFolder)
+	slog.Default().Info(fmt.Sprintf("Processing templates in %s and outputting generated files to %s", opts.TemplateFolder, opts.OutputFolder))
 
 	// Process and render skip files and engines before walking so we only do the rendering operation once.
 	processedSkipFiles, err := processSkipFiles(config.SkipFiles, opts, variables)
@@ -471,7 +481,7 @@ func processTemplateFolder(
 	return filepath.Walk(opts.TemplateFolder, func(path string, info os.FileInfo, err error) error {
 		path = filepath.ToSlash(path)
 		if shouldSkipPath(path, opts, processedSkipFiles) {
-			util.Logger.Printf("Skipping %s", path)
+			slog.Default().Info(fmt.Sprintf("Skipping %s", path))
 			return nil
 		} else if util.IsDir(path) {
 			return createOutputDir(path, opts, variables)
@@ -510,7 +520,7 @@ func createOutputDir(dir string, opts *options.BoilerplateOptions, variables map
 		return err
 	}
 
-	util.Logger.Printf("Creating folder %s", destination)
+	slog.Default().Info(fmt.Sprintf("Creating folder %s", destination))
 	return os.MkdirAll(destination, 0777)
 }
 
@@ -554,7 +564,7 @@ func copyFile(file string, opts *options.BoilerplateOptions, variables map[strin
 		return err
 	}
 
-	util.Logger.Printf("Copying %s to %s", file, destination)
+	slog.Default().Info(fmt.Sprintf("Copying %s to %s", file, destination))
 	return util.CopyFile(file, destination)
 }
 

--- a/util/logger.go
+++ b/util/logger.go
@@ -1,9 +1,0 @@
-package util
-
-import (
-	"log"
-	"os"
-)
-
-// A simple logger we can use to get consistent log formatting through out the app
-var Logger = log.New(os.Stdout, "[boilerplate] ", log.LstdFlags)

--- a/util/prefixer/prefixer.go
+++ b/util/prefixer/prefixer.go
@@ -1,0 +1,43 @@
+package prefixer
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+)
+
+type Handler struct {
+	writer io.Writer
+}
+
+func (h *Handler) Enabled(ctx context.Context, level slog.Level) bool {
+	return true
+}
+
+func (h *Handler) WithAttrs(attrs []slog.Attr) slog.Handler {
+	return h
+}
+
+func (h *Handler) WithGroup(name string) slog.Handler {
+	return h
+}
+
+func (h *Handler) Handle(ctx context.Context, r slog.Record) error {
+	msg := slog.StringValue(r.Message).String()
+	if msg != "" {
+		_, err := io.WriteString(h.writer, fmt.Sprintf("[boilerplate] %s\n", msg))
+		return err
+	}
+
+	return nil
+}
+
+func New() *Handler {
+	handler := &Handler{
+		writer: os.Stderr,
+	}
+
+	return handler
+}

--- a/util/shell.go
+++ b/util/shell.go
@@ -1,6 +1,7 @@
 package util
 
 import (
+	"fmt"
 	"os"
 	"os/exec"
 	"strings"
@@ -10,7 +11,7 @@ import (
 
 // Run the given shell command with the given environment variables and arguments in the given working directory
 func RunShellCommandAndGetOutput(workingDir string, envVars []string, command string, args ...string) (string, error) {
-	Logger.Printf("Running command: %s %s", command, strings.Join(args, " "))
+	fmt.Printf("Running command: %s %s\n", command, strings.Join(args, " "))
 
 	cmd := exec.Command(command, args...)
 
@@ -28,7 +29,7 @@ func RunShellCommandAndGetOutput(workingDir string, envVars []string, command st
 
 // Run the given shell command with the given environment variables and arguments in the given working directory
 func RunShellCommand(workingDir string, envVars []string, command string, args ...string) error {
-	Logger.Printf("Running command: %s %s", command, strings.Join(args, " "))
+	fmt.Printf("Running command: %s %s\n", command, strings.Join(args, " "))
 
 	cmd := exec.Command(command, args...)
 


### PR DESCRIPTION
Fixes https://github.com/gruntwork-io/boilerplate/issues/82.

Currently all logging is done via utils.Logger which just outputs logging to stdout. It would be nice to have more control over logging by silencing logging when not needed or injecting a separate logger (compatible with *slog.Logger).

There is a lot of lines of change here, but it's just creating a slog.Handler that prefixes [boilerplate] to log lines to maintain the existing look and passing an instance of the logger throughout. go is not my primary language though, any feedback is greatly appreciated!

Replaces #189 