### PR TITLE
fix: Add WASM build tags to native-only files

### DIFF
--- a/cli/boilerplate_cli.go
+++ b/cli/boilerplate_cli.go
@@ -1,3 +1,5 @@
+//go:build !(js && wasm)
+
 // Package cli provides the command-line interface for the boilerplate tool.
 package cli
 

--- a/config/get_variables.go
+++ b/config/get_variables.go
@@ -1,3 +1,5 @@
+//go:build !(js && wasm)
+
 package config
 
 import (

--- a/config/get_variables_test.go
+++ b/config/get_variables_test.go
@@ -1,3 +1,5 @@
+//go:build !(js && wasm)
+
 package config //nolint:testpackage
 
 import (

--- a/main.go
+++ b/main.go
@@ -1,3 +1,5 @@
+//go:build !(js && wasm)
+
 package main
 
 import (

--- a/templates/template_processor.go
+++ b/templates/template_processor.go
@@ -1,3 +1,5 @@
+//go:build !(js && wasm)
+
 package templates
 
 import (


### PR DESCRIPTION
While creating #281, Claude Code hit build failures because it was compiling boilerplate using `go build ./...`. CI didn't catch this because the Makefile's `build-wasm` target only compiles `./cmd/wasm/`, which has its own `main.go` that avoids importing the package that caused the build failures (the POSIX-only `syscall.Termios` dependency in `survey/v2/terminal`).

Maybe we'll only ever use the `Makefile` and don't care about this fix? But if so, I'm including it here, kindly generated by Claude Code. Feel free to close if not relevant.

## Summary
- Add `//go:build !(js && wasm)` build tags to files in the native CLI call chain that transitively import `survey/v2`, which uses POSIX-only syscalls unavailable in the `js/wasm` target
- Fixes `GOOS=js GOARCH=wasm go build ./...` failing due to `undefined: syscall.Termios` errors from `survey/v2/terminal`

## Details
The WASM entry point (`cmd/wasm/main.go`) never imports the `config`, `templates`, or `cli` packages — it bypasses the interactive prompt path entirely. However, `go build ./...` compiles every package in the module regardless, and `config/get_variables.go` unconditionally imports `survey/v2` which depends on POSIX syscalls.

Files tagged with `//go:build !(js && wasm)`:
- `main.go` — native CLI entry point
- `cli/boilerplate_cli.go` — CLI app setup (imports `templates`)
- `templates/template_processor.go` — template orchestration (imports `config`)
- `config/get_variables.go` — interactive variable prompting (imports `survey/v2`)
- `config/get_variables_test.go` — tests for the above

## Test plan
- [ ] `go build ./...` — native build still works
- [ ] `go test ./config/... ./templates/... ./cli/...` — affected package tests pass
- [ ] `GOOS=js GOARCH=wasm go build ./...` — full module WASM build now succeeds
- [ ] `GOOS=js GOARCH=wasm go build ./cmd/wasm/` — WASM entry point still builds
